### PR TITLE
Refactor main.go into testable chunks

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,7 @@
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go",
-    tag = "0.4.4",
+    tag = "0.5.0",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "new_go_repository")
@@ -32,4 +32,10 @@ new_go_repository(
     name = "org_golang_x_sys",
     commit = "99f16d856c9836c42d24e7ab64ea72916925fa97",
     importpath = "golang.org/x/sys",
+)
+
+new_go_repository(
+    name = "com_github_bazelbuild_rules_go",
+    importpath = "github.com/bazelbuild/rules_go",
+    tag = "0.5.0",
 )

--- a/bazel/bazel_test.go
+++ b/bazel/bazel_test.go
@@ -28,7 +28,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestProcessInfo(t *testing.T) {
-	b := New()
+	b := &bazel{}
 	got, err := b.processInfo(`KEY: VALUE
 KEY2: VALUE2
 KEY3: value`)
@@ -48,7 +48,7 @@ KEY3: value`)
 }
 
 func TestWriteToStderrAndStdout(t *testing.T) {
-	b := New()
+	b := &bazel{}
 
 	// By default it should write to its own pipe.
 	b.newCommand("version")
@@ -83,7 +83,7 @@ func TestWriteToStderrAndStdout(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	b := New()
+	b := &bazel{}
 	got, err := b.processQuery(`//demo/path/to:target
 //other/path/to:target
 //third_party/path/to:target`)

--- a/ibazel/BUILD
+++ b/ibazel/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_binary(
     name = "ibazel",
@@ -22,10 +22,23 @@ go_binary(
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go", "source_event_handler.go"],
+    srcs = [
+        "ibazel.go",
+        "main.go",
+        "source_event_handler.go",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         "//bazel:go_default_library",
+        "@com_github_fsnotify_fsnotify//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["ibazel_test.go"],
+    library = ":go_default_library",
+    deps = [
         "@com_github_fsnotify_fsnotify//:go_default_library",
     ],
 )

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bazelbuild/bazel-watcher/bazel"
+	"github.com/fsnotify/fsnotify"
+)
+
+var bazelNew = bazel.New
+
+type State string
+
+const (
+	DEBOUNCE_QUERY State = "DEBOUNCE_QUERY"
+	QUERY          State = "QUERY"
+	WAIT           State = "WAIT"
+	DEBOUNCE_RUN   State = "DEBOUNCE_RUN"
+	RUN            State = "RUN"
+	QUIT           State = "QUIT"
+)
+
+const debounceDuration = 100 * time.Millisecond
+const sourceQuery = "kind('source file', deps(set(%s)))"
+const buildQuery = "buildfiles(deps(set(%s)))"
+
+type IBazel struct {
+	b *bazel.Bazel
+
+	buildFileWatcher  *fsnotify.Watcher
+	sourceFileWatcher *fsnotify.Watcher
+
+	sourceEventHandler *SourceEventHandler
+
+	state State
+}
+
+func New() (*IBazel, error) {
+	i := &IBazel{}
+	err := i.setup()
+	if err != nil {
+		return nil, err
+	}
+
+	return i, nil
+}
+
+func (i *IBazel) Cleanup() {
+	i.buildFileWatcher.Close()
+	i.sourceFileWatcher.Close()
+}
+
+func (i *IBazel) setup() error {
+	var err error
+	// Even though we are going to recreate this when the query happens, create
+	// the pointer we will use to refer to the watchers right now.
+	i.buildFileWatcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	i.sourceFileWatcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	i.sourceEventHandler = NewSourceEventHandler(i.sourceFileWatcher)
+
+	return nil
+}
+
+// Run the specified target (singular) in the IBazel loop.
+func (i *IBazel) Run(target string) error {
+	return i.loop("run", i.run, []string{target})
+}
+
+// Build the specified targets in the IBazel loop.
+func (i *IBazel) Build(targets ...string) error {
+	return i.loop("build", i.build, targets)
+}
+
+// Test the specified targets in the IBazel loop.
+func (i *IBazel) Test(targets ...string) error {
+	return i.loop("test", i.test, targets)
+}
+
+func (i *IBazel) loop(command string, commandToRun func(...string), targets []string) error {
+	joinedTargets := strings.Join(targets, " ")
+
+	i.state = QUERY
+	for {
+		i.iteration(command, commandToRun, targets, joinedTargets)
+	}
+
+	return nil
+}
+
+func (i *IBazel) iteration(command string, commandToRun func(...string), targets []string, joinedTargets string) {
+	fmt.Printf("State: %s\n", i.state)
+	switch i.state {
+	case WAIT:
+		select {
+		case <-i.sourceEventHandler.SourceFileEvents:
+			fmt.Printf("Detected source change. Rebuilding...\n")
+			i.state = DEBOUNCE_RUN
+		case <-i.buildFileWatcher.Events:
+			fmt.Printf("Detected build graph change. Requerying...\n")
+			i.state = DEBOUNCE_QUERY
+		}
+	case DEBOUNCE_QUERY:
+		select {
+		case <-i.buildFileWatcher.Events:
+			i.state = DEBOUNCE_QUERY
+		case <-time.After(debounceDuration):
+			i.state = QUERY
+		}
+	case QUERY:
+		// Query for which files to watch.
+		fmt.Printf("Querying for BUILD files...\n")
+		i.watchFiles(fmt.Sprintf(buildQuery, joinedTargets), i.buildFileWatcher)
+		fmt.Printf("Querying for source files...\n")
+		i.watchFiles(fmt.Sprintf(sourceQuery, joinedTargets), i.sourceFileWatcher)
+		i.state = RUN
+	case DEBOUNCE_RUN:
+		select {
+		case <-i.sourceEventHandler.SourceFileEvents:
+			i.state = DEBOUNCE_RUN
+		case <-time.After(debounceDuration):
+			i.state = RUN
+		}
+	case RUN:
+		i.state = WAIT
+		fmt.Printf("%sing %s\n", strings.Title(command), joinedTargets)
+		commandToRun(targets...)
+	}
+}
+
+func (i *IBazel) build(targets ...string) {
+	b := bazelNew()
+
+	b.Cancel()
+	b.WriteToStderr(true)
+	b.WriteToStdout(true)
+	err := b.Build(targets...)
+	if err != nil {
+		fmt.Printf("Build error: %v", err)
+		return
+	}
+}
+
+func (i *IBazel) test(targets ...string) {
+	b := bazelNew()
+
+	b.Cancel()
+	b.WriteToStderr(true)
+	b.WriteToStdout(true)
+	err := b.Test(targets...)
+	if err != nil {
+		fmt.Printf("Build error: %v", err)
+		return
+	}
+}
+
+func (i *IBazel) run(targets ...string) {
+	b := bazelNew()
+
+	b.Cancel()
+	b.WriteToStderr(true)
+	b.WriteToStdout(true)
+
+	// Start run in a goroutine so that it doesn't block watching for files that
+	// have changed.
+	go b.Run(targets...)
+}
+
+func queryForSourceFiles(query string) []string {
+	b := bazelNew()
+	b.WriteToStderr(false)
+	b.WriteToStdout(false)
+
+	res, err := b.Query(query)
+	if err != nil {
+		fmt.Printf("Error running Bazel %s\n", err)
+	}
+
+	toWatch := make([]string, 0, 10000)
+	for _, line := range res {
+		if strings.HasPrefix(line, "@") {
+			continue
+		}
+		if strings.HasPrefix(line, "//external") {
+			continue
+		}
+
+		// For files that are served from the root they will being with "//:". This
+		// is a problematic string because, for example, "//:demo.sh" will become
+		// "/demo.sh" which is in the root of the filesystem and is unlikely to exist.
+		if strings.HasPrefix(line, "//:") {
+			line = line[3:]
+		}
+
+		toWatch = append(toWatch, strings.Replace(strings.TrimPrefix(line, "//"), ":", "/", 1))
+	}
+
+	return toWatch
+}
+
+func (i *IBazel) watchFiles(query string, watcher *fsnotify.Watcher) {
+	toWatch := queryForSourceFiles(query)
+
+	// TODO: Figure out how to unwatch files that are no longer included
+
+	for _, line := range toWatch {
+		fmt.Printf("Watching: %s\n", line)
+		err := watcher.Add(line)
+		if err != nil {
+			fmt.Printf("Error watching file %v\nError: %v\n", line, err)
+			continue
+		}
+	}
+}

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"os/exec"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/bazelbuild/bazel-watcher/bazel"
+	"github.com/fsnotify/fsnotify"
+)
+
+type MockBazel struct {
+	actions       [][]string
+	queryResponse []string
+}
+
+func (b *MockBazel) WriteToStderr(v bool) {
+	b.actions = append(b.actions, []string{"WriteToStderr"})
+}
+func (b *MockBazel) WriteToStdout(v bool) {
+	b.actions = append(b.actions, []string{"WriteToStdout"})
+}
+func (b *MockBazel) Info() (map[string]string, error) {
+	b.actions = append(b.actions, []string{"Info"})
+	return map[string]string{}, nil
+}
+func (b *MockBazel) Query(args ...string) ([]string, error) {
+	b.actions = append(b.actions, append([]string{"Query"}, args...))
+	return b.queryResponse, nil
+}
+func (b *MockBazel) Build(args ...string) error {
+	b.actions = append(b.actions, append([]string{"Build"}, args...))
+	return nil
+}
+func (b *MockBazel) Test(args ...string) error {
+	b.actions = append(b.actions, append([]string{"Test"}, args...))
+	return nil
+}
+func (b *MockBazel) Run(args ...string) (*exec.Cmd, error) {
+	b.actions = append(b.actions, append([]string{"Run"}, args...))
+	return nil, nil
+}
+func (b *MockBazel) Cancel() {
+	b.actions = append(b.actions, []string{"Cancel"})
+}
+
+var mockBazel *MockBazel
+
+func init() {
+	// Replace the bazle object creation function with one that makes my mock.
+	bazelNew = func() bazel.Bazel {
+		mockBazel = &MockBazel{}
+		return mockBazel
+	}
+}
+
+func TestIBazelLifecycle(t *testing.T) {
+	i, err := New()
+	if err != nil {
+		t.Errorf("Error creating IBazel: %s", err)
+	}
+
+	i.Cleanup()
+
+	// Now inspect private API. If things weren't closed properly this will block
+	// and the test will timeout.
+	<-i.sourceFileWatcher.Events
+	<-i.buildFileWatcher.Events
+}
+
+func TestIBazelLoop(t *testing.T) {
+	i, err := New()
+	if err != nil {
+		t.Errorf("Error creating IBazel: %s", err)
+	}
+
+	// Replace the file watching channel with one that has a buffer.
+	i.buildFileWatcher.Events = make(chan fsnotify.Event, 1)
+	i.sourceEventHandler.SourceFileEvents = make(chan fsnotify.Event, 1)
+
+	defer i.Cleanup()
+
+	// The process for testing this is going to be to emit events to the channels
+	// that are associated with these objects and walk the state transition
+	// graph.
+
+	// First let's consume all the events from all the channels we care about
+	called := false
+	command := func(targets ...string) {
+		called = true
+	}
+
+	i.state = QUERY
+	step := func() {
+		i.iteration("demo", command, []string{}, "")
+	}
+	assertRun := func() {
+		if called == false {
+			_, file, line, _ := runtime.Caller(1) // decorate + log + public function.
+			t.Errorf("%s:%v Should have run the provided comand", file, line)
+		}
+		called = false
+	}
+	assertState := func(state State) {
+		if i.state != state {
+			_, file, line, _ := runtime.Caller(1) // decorate + log + public function.
+			t.Errorf("%s:%v Expected state to be %s but was %s", file, line, state, i.state)
+		}
+	}
+
+	// Pretend a fairly normal event chain happens.
+	// Start, run the program, write a source file, run, write a build file, run.
+
+	assertState(QUERY)
+	step()
+	assertState(RUN)
+	step() // Actually run the command
+	assertRun()
+	assertState(WAIT)
+	// Source file change.
+	i.sourceEventHandler.SourceFileEvents <- fsnotify.Event{}
+	step()
+	assertState(DEBOUNCE_RUN)
+	step()
+	// Don't send another event in to test the timer
+	assertState(RUN)
+	step() // Actually run the command
+	assertRun()
+	assertState(WAIT)
+	// Build file change.
+	i.buildFileWatcher.Events <- fsnotify.Event{}
+	step()
+	assertState(DEBOUNCE_QUERY)
+	// Don't send another event in to test the timer
+	step()
+	assertState(QUERY)
+	step()
+	assertState(RUN)
+	step() // Actually run the command
+	assertRun()
+	assertState(WAIT)
+}
+
+func TestIBazelBuild(t *testing.T) {
+	i, err := New()
+	if err != nil {
+		t.Errorf("Error creating IBazel: %s", err)
+	}
+
+	defer i.Cleanup()
+
+	i.build("//path/to:target")
+	expected := [][]string{
+		[]string{"Cancel"},
+		[]string{"WriteToStderr"},
+		[]string{"WriteToStdout"},
+		[]string{"Build", "//path/to:target"},
+	}
+
+	if !reflect.DeepEqual(mockBazel.actions, expected) {
+		t.Errorf("Build didn't meet expecations.\nWant: %s\nGot:  %s", expected, mockBazel.actions)
+	}
+}
+
+func TestIBazelTest(t *testing.T) {
+	i, err := New()
+	if err != nil {
+		t.Errorf("Error creating IBazel: %s", err)
+	}
+
+	defer i.Cleanup()
+
+	i.test("//path/to:target")
+	expected := [][]string{
+		[]string{"Cancel"},
+		[]string{"WriteToStderr"},
+		[]string{"WriteToStdout"},
+		[]string{"Test", "//path/to:target"},
+	}
+
+	if !reflect.DeepEqual(mockBazel.actions, expected) {
+		t.Errorf("Test didn't meet expecations.\nWant: %s\nGot:  %s", expected, mockBazel.actions)
+	}
+}
+
+func TestIBazelRun(t *testing.T) {
+	i, err := New()
+	if err != nil {
+		t.Errorf("Error creating IBazel: %s", err)
+	}
+
+	defer i.Cleanup()
+
+	i.run("//path/to:target")
+
+	expected := [][]string{
+		[]string{"Cancel"},
+		[]string{"WriteToStderr"},
+		[]string{"WriteToStdout"},
+		[]string{"Run", "//path/to:target"},
+	}
+
+	// Sleep for 50ms to let the goroutine launched by run get scheduled/execute.
+	time.Sleep(50 * time.Millisecond)
+
+	if !reflect.DeepEqual(mockBazel.actions, expected) {
+		t.Errorf("Test didn't meet expecations.\nWant: %s\nGot:  %s", expected, mockBazel.actions)
+	}
+}


### PR DESCRIPTION
The iBazel object performs the same as the main function did before but
is broken into smaller, tested parts.