### PR TITLE
Add a basic argument processor.

### DIFF
--- a/bazel/bazel.go
+++ b/bazel/bazel.go
@@ -23,6 +23,7 @@ import (
 )
 
 type Bazel interface {
+	SetArguments([]string)
 	WriteToStderr(v bool)
 	WriteToStdout(v bool)
 	Info() (map[string]string, error)
@@ -35,6 +36,7 @@ type Bazel interface {
 
 type bazel struct {
 	cmd           *exec.Cmd
+	args          []string
 	ctx           context.Context
 	cancel        context.CancelFunc
 	writeToStderr bool
@@ -43,6 +45,10 @@ type bazel struct {
 
 func New() Bazel {
 	return &bazel{}
+}
+
+func (b *bazel) SetArguments(args []string) {
+	b.args = args
 }
 
 // WriteToStderr when running an operation.
@@ -149,7 +155,7 @@ func (b *bazel) processQuery(info string) ([]string, error) {
 }
 
 func (b *bazel) Build(args ...string) error {
-	b.newCommand("build", args...)
+	b.newCommand("build", append(b.args, args...)...)
 
 	err := b.cmd.Run()
 
@@ -157,7 +163,7 @@ func (b *bazel) Build(args ...string) error {
 }
 
 func (b *bazel) Test(args ...string) error {
-	b.newCommand("test", append([]string{"--test_output=streamed"}, args...)...)
+	b.newCommand("test", append(b.args, args...)...)
 
 	err := b.cmd.Run()
 

--- a/ibazel/BUILD
+++ b/ibazel/BUILD
@@ -36,7 +36,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["ibazel_test.go"],
+    srcs = [
+        "ibazel_test.go",
+        "main_test.go",
+    ],
     library = ":go_default_library",
     deps = [
         "@com_github_fsnotify_fsnotify//:go_default_library",

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -29,6 +29,11 @@ import (
 type MockBazel struct {
 	actions       [][]string
 	queryResponse []string
+	args          []string
+}
+
+func (b *MockBazel) SetArguments(args []string) {
+	b.args = args
 }
 
 func (b *MockBazel) WriteToStderr(v bool) {

--- a/ibazel/main_test.go
+++ b/ibazel/main_test.go
@@ -1,0 +1,76 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParsingArgs(t *testing.T) {
+	for _, c := range []struct {
+		in        []string
+		targets   []string
+		bazelArgs []string
+		args      []string
+	}{
+		// Empty case.
+		{[]string{}, nil, nil, nil},
+		// Only targets.
+		{[]string{"//my/target"}, []string{"//my/target"}, nil, nil},
+		// arguments after a --.
+		{[]string{"--", "--my_program_flag"}, nil, nil, []string{"--my_program_flag"}},
+		// Whitelisted bazel flag.
+		{[]string{"--test_output=streaming"}, nil, []string{"--test_output=streaming"}, nil},
+		// Whitelisted bazel flag, arg, and target.
+		{[]string{"--test_output=streaming", "--", "--my_program_flag"}, nil, []string{"--test_output=streaming"}, []string{"--my_program_flag"}},
+	} {
+		targets, bazelArgs, args := parseArgs(c.in)
+		if !reflect.DeepEqual(c.targets, targets) {
+			t.Errorf("Targets not equal for args: %v\nGot:  %v\nWant: %v",
+				c.in, targets, c.targets)
+		}
+		if !reflect.DeepEqual(c.bazelArgs, bazelArgs) {
+			t.Errorf("Bazel args not equal for args: %v\nGot:  %v\nWant: %v",
+				c.in, bazelArgs, c.bazelArgs)
+		}
+		if !reflect.DeepEqual(c.args, args) {
+			t.Errorf("Additional args not equal for args: %v\nGot:  %v\nWant: %v",
+				c.in, args, c.args)
+		}
+	}
+}
+
+func TestIsOverrideableBazelFlag(t *testing.T) {
+	// Set some extra flags for testing
+	overrideableBazelFlags = []string{
+		"--test_output=",
+	}
+
+	for _, c := range []struct {
+		arg          string
+		overrideable bool
+	}{
+		{"--test", false},
+		{"--i_love_ponies", false},
+		{"--test_output", false},
+		{"--test_output=streamed", true},
+		{"--test_output_with_mooses=false", false},
+	} {
+		if isOverrideableBazelFlag(c.arg) != c.overrideable {
+			t.Errorf("isOverrideableBazelFlag(%v) == %v (Got), Wanted %v", c.arg, !c.overrideable, c.overrideable)
+		}
+	}
+}


### PR DESCRIPTION
Now when you pass in arguments to ibazel it should pass them through to
bazel or to your running job if you pass it after a `--`.  Fixes #13.

Also this no longer sets --test_output=streamed by default.