### PR TITLE
Added a command abstraction.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ os:
   - osx
 
 env:
-  - V=0.5.2
+  - V=0.5.4
 
 before_install:
   - |

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,7 @@
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "701794b80f6b824f75a30181a2a9f240bd0acbec",
+    commit = "97cde97cc32f8d82b787d0fadcdcfacc599f5f55",
     remote = "https://github.com/bazelbuild/rules_go",
 )
 

--- a/ibazel/BUILD
+++ b/ibazel/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_binary")
 
 go_binary(
     name = "ibazel",
@@ -32,6 +32,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//bazel:go_default_library",
+        "//ibazel/command:go_default_library",
         "@com_github_fsnotify_fsnotify//:go_default_library",
     ],
 )
@@ -47,6 +48,7 @@ go_test(
     deps = [
         "//bazel:go_default_library",
         "//bazel/testing:go_default_library",
+        "//ibazel/command:go_default_library",
         "@com_github_fsnotify_fsnotify//:go_default_library",
     ],
 )

--- a/ibazel/command/BUILD
+++ b/ibazel/command/BUILD
@@ -12,11 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["mock.go"],
-    importpath = "github.com/bazelbuild/bazel-watcher/bazel/testing",
-    visibility = ["//visibility:public"],
+    srcs = [
+        "command.go",
+        "default_command.go",
+    ],
+    importpath = "github.com/bazelbuild/bazel-watcher/ibazel/command",
+    visibility = ["//ibazel:__subpackages__"],
+    deps = ["//bazel:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "command_test.go",
+        "default_command_test.go",
+    ],
+    importpath = "github.com/bazelbuild/bazel-watcher/ibazel/command",
+    library = ":go_default_library",
+    deps = ["//bazel/testing:go_default_library"],
 )

--- a/ibazel/command/command.go
+++ b/ibazel/command/command.go
@@ -1,0 +1,87 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/bazelbuild/bazel-watcher/bazel"
+)
+
+var execCommand = exec.Command
+
+// Command is an object that wraps the logic of running a task in Bazel and
+// manipulating it.
+type Command interface {
+	Start()
+	Terminate()
+	NotifyOfChanges()
+	IsSubprocessRunning() bool
+}
+
+// start will be called by most implementations since this logic is extremely
+// common.
+func start(b bazel.Bazel, target string, args []string) *exec.Cmd {
+	tmpfile, err := ioutil.TempFile("", "bazel_script_path")
+	if err != nil {
+		fmt.Print(err)
+	}
+	// Close the file so bazel can write over it
+	if err := tmpfile.Close(); err != nil {
+		fmt.Print(err)
+	}
+
+	// Start by building the binary
+	b.Run("--script_path="+tmpfile.Name(), target)
+
+	targetPath := tmpfile.Name()
+
+	// Now that we have built the target, construct a executable form of it for
+	// execution in a go routine.
+	cmd := execCommand(targetPath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Set a process group id (PGID) on the subprocess. This is
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// Start run in a goroutine so that it doesn't block watching for files that
+	// have changed.
+	if err := cmd.Start(); err != nil {
+		fmt.Printf("Error starting process: %v\n", err)
+	}
+
+	return cmd
+}
+
+func subprocessRunning(cmd *exec.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+	if cmd.Process == nil {
+		return false
+	}
+	if cmd.ProcessState != nil {
+		if cmd.ProcessState.Exited() {
+			return false
+		}
+	}
+
+	return true
+}

--- a/ibazel/command/command_test.go
+++ b/ibazel/command/command_test.go
@@ -1,0 +1,86 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	mock_bazel "github.com/bazelbuild/bazel-watcher/bazel/testing"
+)
+
+var oldExecCommand = exec.Command
+
+func assertKilled(t *testing.T, cmd *exec.Cmd) {
+	if err := cmd.Wait(); err != nil {
+		if cmd.ProcessState.Success() {
+			t.Errorf("Subprocess terminated from \"natural\" causes, which means the job ran till its timeout then existed. The Run method should have killed it before then.")
+		}
+		if cmd.ProcessState == nil {
+			t.Errorf("Killable subprocess was never started. State: %v, Err: %v", cmd.ProcessState, err)
+		}
+	}
+}
+
+func TestSubprocessRunning(t *testing.T) {
+	if subprocessRunning(nil) {
+		t.Errorf("Nil subprocesses don't run")
+	}
+
+	cmd := exec.Command("sleep", ".1s")
+
+	if subprocessRunning(cmd) {
+		t.Errorf("New subprocess shouldn't have been started yet. State: %v", cmd.ProcessState)
+	}
+
+	cmd.Start()
+
+	if !subprocessRunning(cmd) {
+		t.Errorf("New subprocess was never started. State: %v", cmd.ProcessState)
+	}
+
+	err := cmd.Wait()
+	if err != nil || subprocessRunning(cmd) {
+		t.Errorf("Subprocess finished with error: %v State: %v", err, cmd.ProcessState)
+	}
+}
+
+func TestDefaultCommand_Start(t *testing.T) {
+	// Set up mock execCommand and prep it to be returned
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return oldExecCommand("ls") // Every system has ls.
+	}
+	defer func() { execCommand = oldExecCommand }()
+
+	b := &mock_bazel.MockBazel{}
+
+	cmd := start(b, "//path/to:target", []string{"moo"})
+	cmd.Start()
+
+	if cmd.Stdout != os.Stdout {
+		t.Errorf("Didn't set Stdout correctly")
+	}
+	if cmd.Stderr != os.Stderr {
+		t.Errorf("Didn't set Stderr correctly")
+	}
+	if cmd.SysProcAttr.Setpgid != true {
+		t.Errorf("Never set PGID (will prevent killing process trees -- see notes in ibazel.go")
+	}
+
+	b.AssertActions(t, [][]string{
+		[]string{"Run", "--script_path=.*", "//path/to:target"},
+	})
+}

--- a/ibazel/command/default_command.go
+++ b/ibazel/command/default_command.go
@@ -1,0 +1,67 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"os/exec"
+	"syscall"
+
+	"github.com/bazelbuild/bazel-watcher/bazel"
+)
+
+type defaultCommand struct {
+	target string
+	b      bazel.Bazel
+	args   []string
+	cmd    *exec.Cmd
+}
+
+// DefaultCommand is the normal mode of interacting with iBazel. If you start a
+// server in this mode and notify of changes the server will be killed and
+// restarted.
+func DefaultCommand(bazel bazel.Bazel, target string, args []string) Command {
+	return &defaultCommand{
+		target: target,
+		b:      bazel,
+		args:   args,
+	}
+}
+
+func (c *defaultCommand) Terminate() {
+	if !subprocessRunning(c.cmd) {
+		return
+	}
+
+	// Kill it with fire by sending SIGKILL to the process PID which should
+	// propagate down to any subprocesses in the PGID (Process Group ID). To
+	// send to the PGID, send the signal to the negative of the process PID.
+	// Normally I would do this by calling c.cmd.Process.Signal, but that
+	// only goes to the PID not the PGID.
+	syscall.Kill(-c.cmd.Process.Pid, syscall.SIGKILL)
+	c.cmd.Wait()
+	c.cmd = nil
+}
+
+func (c *defaultCommand) Start() {
+	c.cmd = start(c.b, c.target, c.args)
+}
+
+func (c *defaultCommand) NotifyOfChanges() {
+	c.Terminate()
+}
+
+func (c *defaultCommand) IsSubprocessRunning() bool {
+	return subprocessRunning(c.cmd)
+}

--- a/ibazel/command/default_command_test.go
+++ b/ibazel/command/default_command_test.go
@@ -1,0 +1,50 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+
+	mock_bazel "github.com/bazelbuild/bazel-watcher/bazel/testing"
+)
+
+func TestDefaultCommand(t *testing.T) {
+	toKill := exec.Command("sleep", "5s")
+	toKill.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	b := &mock_bazel.MockBazel{}
+	c := &defaultCommand{
+		args:   []string{"moo"},
+		b:      b,
+		cmd:    toKill,
+		target: "//path/to:target",
+	}
+
+	if c.IsSubprocessRunning() {
+		t.Errorf("New subprocess shouldn't have been started yet. State: %v", toKill.ProcessState)
+	}
+
+	toKill.Start()
+
+	if !c.IsSubprocessRunning() {
+		t.Errorf("New subprocess was never started. State: %v", toKill.ProcessState)
+	}
+
+	// This is synonymous with killing the job so use it to kill the job and test everything.
+	c.NotifyOfChanges()
+	assertKilled(t, toKill)
+}

--- a/ibazel/source_event_handler.go
+++ b/ibazel/source_event_handler.go
@@ -14,10 +14,10 @@
 
 package main
 
-import 	"github.com/fsnotify/fsnotify"
+import "github.com/fsnotify/fsnotify"
 
 type SourceEventHandler struct {
-	SourceFileEvents chan fsnotify.Event
+	SourceFileEvents  chan fsnotify.Event
 	SourceFileWatcher *fsnotify.Watcher
 }
 
@@ -36,10 +36,10 @@ func (s *SourceEventHandler) Listen() {
 }
 
 func NewSourceEventHandler(sourceFileWatcher *fsnotify.Watcher) *SourceEventHandler {
-    handler := &SourceEventHandler{
-        make(chan fsnotify.Event),
-        sourceFileWatcher,
-    }
-    go handler.Listen()
-    return handler
+	handler := &SourceEventHandler{
+		make(chan fsnotify.Event),
+		sourceFileWatcher,
+	}
+	go handler.Listen()
+	return handler
 }


### PR DESCRIPTION
In an effort to make it so that different bazel labels will have different
behavoir when running ibazel we added an abstraction of what command is
running. This abstraction encapsulates how the command should start, terminate
itself and respond to changes in build dependencies. Different commands will
respond to changes in different ways. By default, the command will terminate
and restart. In the future we envision some bazel targets being having a label
which tells ibazel to not kill the command when changes are detected. Instead
they can do different sorts of behavoir (ie performing a hotswap of resources
for a java binary).