### PR TITLE
Catch SIGTERM instead of SIGKILL

### DIFF
--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -88,7 +88,7 @@ func New() (*IBazel, error) {
 }
 
 func (i *IBazel) handleSignals() {
-	// Got an OS signal (SIGINT, SIGKILL).
+	// Got an OS signal (SIGINT, SIGTERM).
 	sig := <-i.sigs
 
 	switch sig {
@@ -100,9 +100,9 @@ func (i *IBazel) handleSignals() {
 			osExit(3)
 		}
 		break
-	case syscall.SIGKILL:
+	case syscall.SIGTERM:
 		if i.cmd != nil && i.cmd.IsSubprocessRunning() {
-			fmt.Fprintf(os.Stderr, "\nSubprocess killed from getting SIGKILL\n")
+			fmt.Fprintf(os.Stderr, "\nSubprocess killed from getting SIGTERM\n")
 			i.cmd.Terminate()
 		}
 		osExit(3)

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -347,7 +347,7 @@ func TestHandleSignals_SIGINT(t *testing.T) {
 	assertEqual(t, attemptedExit, 3, "Should have exited ibazel")
 }
 
-func TestHandleSignals_SIGKILL(t *testing.T) {
+func TestHandleSignals_SIGTERM(t *testing.T) {
 	i := &IBazel{}
 	err := i.setup()
 	if err != nil {
@@ -356,7 +356,7 @@ func TestHandleSignals_SIGKILL(t *testing.T) {
 	i.sigs = make(chan os.Signal, 1)
 	defer i.Cleanup()
 
-	// Now test sending SIGKILL
+	// Now test sending SIGTERM
 	attemptedExit := false
 	osExit = func(i int) {
 		attemptedExit = true
@@ -367,7 +367,7 @@ func TestHandleSignals_SIGKILL(t *testing.T) {
 	cmd.Start()
 	i.cmd = cmd
 
-	i.sigs <- syscall.SIGKILL
+	i.sigs <- syscall.SIGTERM
 	i.handleSignals()
 	cmd.assertTerminated(t)
 


### PR DESCRIPTION
It's impossible to catch SIGKILL (`kill -9`); the kernel immediately destroys the process without notifying it. You should be trying to catch SIGTERM (`kill`) instead.