### PR TITLE
Update rules_go to 0.7.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-rules_go_commit = "f37989f66a6980436d6c78651e801063f2f55b36"
+rules_go_commit = "0bd97fc6ae48d4124e1a8506bcb397be766f8b83"
 
 git_repository(
     name = "io_bazel_rules_go",


### PR DESCRIPTION
As an Ubuntu user, I had the same issue with rules_go that @genehwung mentioned in #26. This has since been fixed by https://github.com/bazelbuild/rules_go/pull/850