### PR TITLE
Exit when query fails and pass through its stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Right now this repo supports `build`, `test`, and `run`.
 
 ## Additional notes
 
+### Termination
+
+SIGINT has to be sent twice to kill ibazel: once to kill the subprocess, and
+the second time for ibazel itself. Also, ibazel will exit on its own when a
+bazel query fails, but it will stay alive when a build, test, or run fails.
+We use an exit code of 3 for a signal termination, and 4 for a query failure,
+but these codes are subject to change.
+
 ### What about the `--watchfs` flag?
 
 Bazel has a flag called `--watchfs` which, according to the bazel command-line

--- a/bazel/bazel.go
+++ b/bazel/bazel.go
@@ -15,6 +15,7 @@
 package bazel
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -146,11 +147,15 @@ func (b *bazel) Query(args ...string) (*blaze_query.QueryResult, error) {
 	b.WriteToStderr(false)
 	b.WriteToStdout(false)
 
-	out, err := b.cmd.Output()
+	var stdout, stderr bytes.Buffer
+	b.cmd.Stdout = &stdout
+	b.cmd.Stderr = &stderr
+	err := b.cmd.Run()
 	if err != nil {
+		fmt.Fprintf(os.Stderr, stderr.String())
 		return nil, err
 	}
-	return b.processQuery(out)
+	return b.processQuery(stdout.Bytes())
 }
 
 func (b *bazel) processQuery(out []byte) (*blaze_query.QueryResult, error) {

--- a/bazel/bazel.go
+++ b/bazel/bazel.go
@@ -15,7 +15,6 @@
 package bazel
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -143,19 +142,15 @@ func (b *bazel) Query(args ...string) (*blaze_query.QueryResult, error) {
 	blazeArgs := append([]string(nil), "--output=proto", "--order_output=no")
 	blazeArgs = append(blazeArgs, args...)
 
+        b.WriteToStderr(true)
+        b.WriteToStdout(false)
 	b.newCommand("query", blazeArgs...)
-	b.WriteToStderr(false)
-	b.WriteToStdout(false)
 
-	var stdout, stderr bytes.Buffer
-	b.cmd.Stdout = &stdout
-	b.cmd.Stderr = &stderr
-	err := b.cmd.Run()
+	out, err := b.cmd.Output()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, stderr.String())
 		return nil, err
 	}
-	return b.processQuery(stdout.Bytes())
+	return b.processQuery(out)
 }
 
 func (b *bazel) processQuery(out []byte) (*blaze_query.QueryResult, error) {
@@ -185,9 +180,9 @@ func (b *bazel) Test(args ...string) error {
 
 // Build the specified target (singular) and run it with the given arguments.
 func (b *bazel) Run(args ...string) (*exec.Cmd, error) {
-	b.newCommand("run", args...)
 	b.WriteToStderr(true)
-	b.WriteToStdout(true)
+        b.WriteToStdout(true)
+        b.newCommand("run", args...)
 	b.cmd.Stdin = os.Stdin
 
 	err := b.cmd.Run()

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -284,8 +284,6 @@ func (i *IBazel) run(targets ...string) {
 
 func (i *IBazel) queryRule(rule string) (*blaze_query.Rule, error) {
 	b := i.newBazel()
-	b.WriteToStderr(false)
-	b.WriteToStdout(false)
 
 	res, err := b.Query(rule)
 	if err != nil {
@@ -304,13 +302,11 @@ func (i *IBazel) queryRule(rule string) (*blaze_query.Rule, error) {
 
 func (i *IBazel) queryForSourceFiles(query string) []string {
 	b := i.newBazel()
-	b.WriteToStderr(false)
-	b.WriteToStdout(false)
 
 	res, err := b.Query(query)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error running Bazel %s\n", err)
-		osExit(1)
+		osExit(4)
 	}
 
 	toWatch := make([]string, 0, 10000)

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -288,6 +288,7 @@ func (i *IBazel) queryRule(rule string) (*blaze_query.Rule, error) {
 	res, err := b.Query(rule)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error running Bazel %s\n", err)
+                osExit(4)
 	}
 
 	for _, target := range res.Target {

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -310,7 +310,7 @@ func (i *IBazel) queryForSourceFiles(query string) []string {
 	res, err := b.Query(query)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error running Bazel %s\n", err)
-		return []string{}
+		osExit(1)
 	}
 
 	toWatch := make([]string, 0, 10000)


### PR DESCRIPTION
From the discussion on #2, it seems like the consensus was that ibazel should exit if the query fails (but not if the build fails).

Fixes: #2
Fixes: #54