### PR TITLE
Live reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Bazel watcher
 
-Bazel ≥0.5.2 | linux-x86_64 | ubuntu_15.10-x86_64 | darwin-x86_64
-:---: | :---: | :---: | :---:
-[![Build Status](https://travis-ci.org/bazelbuild/bazel-watcher.svg?branch=master)](https://travis-ci.org/bazelbuild/bazel-watcher) | [![Build Status](http://ci.bazel.io/buildStatus/icon?job=bazel-watcher/BAZEL_VERSION=latest,PLATFORM_NAME=linux-x86_64)](http://ci.bazel.io/job/bazel-watcher/BAZEL_VERSION=latest,PLATFORM_NAME=linux-x86_64) | [![Build Status](http://ci.bazel.io/buildStatus/icon?job=bazel-watcher/BAZEL_VERSION=latest,PLATFORM_NAME=ubuntu_15.10-x86_64)](http://ci.bazel.io/job/bazel-watcher/BAZEL_VERSION=latest,PLATFORM_NAME=ubuntu_15.10-x86_64) | [![Build Status](http://ci.bazel.io/buildStatus/icon?job=bazel-watcher/BAZEL_VERSION=latest,PLATFORM_NAME=darwin-x86_64)](http://ci.bazel.io/job/bazel-watcher/BAZEL_VERSION=latest,PLATFORM_NAME=darwin-x86_64)
-
+[![Build Status](https://ci.bazel.io/buildStatus/icon?job=Global%2Fbazel-watcher)](https://ci.bazel.io/blue/organizations/jenkins/Global%2Fbazel-watcher/activity/)
 
 Note: This is not an official Google product.
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,6 +33,18 @@ go_repository(
 )
 
 go_repository(
+    name = "com_github_jaschaephraim_lrserver",
+    commit = "0dac7fe720b94c2a85f984dbc7406a495c35b25b",
+    importpath = "github.com/jaschaephraim/lrserver",
+)
+
+go_repository(
+    name = "com_github_gorilla_websocket",
+    commit = "7ca4275b84a9d500f68971c8c4a97f0ec18eb889",
+    importpath = "github.com/gorilla/websocket",
+)
+
+go_repository(
     name = "org_golang_x_sys",
     commit = "99f16d856c9836c42d24e7ab64ea72916925fa97",
     importpath = "golang.org/x/sys",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,9 +33,9 @@ go_repository(
 )
 
 go_repository(
-    name = "com_github_jaschaephraim_lrserver",
-    commit = "0dac7fe720b94c2a85f984dbc7406a495c35b25b",
-    importpath = "github.com/jaschaephraim/lrserver",
+    name = "com_github_gregmagolan_lrserver",
+    commit = "2e678573ccbdc2144f01a52f3219bf67cd5f0fc8",
+    importpath = "github.com/gregmagolan/lrserver",
 )
 
 go_repository(

--- a/ibazel/BUILD
+++ b/ibazel/BUILD
@@ -35,6 +35,8 @@ go_library(
         "//ibazel/command:go_default_library",
         "//third_party/bazel/master/src/main/protobuf:go_default_library",
         "@com_github_fsnotify_fsnotify//:go_default_library",
+        "@com_github_gorilla_websocket//:go_default_library",
+        "@com_github_jaschaephraim_lrserver//:go_default_library",
     ],
 )
 
@@ -52,6 +54,8 @@ go_test(
         "//ibazel/command:go_default_library",
         "//third_party/bazel/master/src/main/protobuf:go_default_library",
         "@com_github_fsnotify_fsnotify//:go_default_library",
+        "@com_github_gorilla_websocket//:go_default_library",
+        "@com_github_jaschaephraim_lrserver//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/ibazel/BUILD
+++ b/ibazel/BUILD
@@ -36,7 +36,7 @@ go_library(
         "//third_party/bazel/master/src/main/protobuf:go_default_library",
         "@com_github_fsnotify_fsnotify//:go_default_library",
         "@com_github_gorilla_websocket//:go_default_library",
-        "@com_github_jaschaephraim_lrserver//:go_default_library",
+        "@com_github_gregmagolan_lrserver//:go_default_library",
     ],
 )
 
@@ -55,7 +55,7 @@ go_test(
         "//third_party/bazel/master/src/main/protobuf:go_default_library",
         "@com_github_fsnotify_fsnotify//:go_default_library",
         "@com_github_gorilla_websocket//:go_default_library",
-        "@com_github_jaschaephraim_lrserver//:go_default_library",
+        "@com_github_gregmagolan_lrserver//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -299,6 +299,8 @@ func (i *IBazel) startLiveReloadServer() {
 		if (testPort(port)) {
 			i.lrserver = lrserver.New("live reload", port)
 			go i.lrserver.ListenAndServe()
+			url := fmt.Sprintf("http://localhost:%d/livereload.js?snipver=1", port)
+			os.Setenv("IBAZEL_LIVERELOAD_URL", url)
 			return
 		}
 	}

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -347,7 +347,7 @@ func TestHandleSignals_SIGINT(t *testing.T) {
 	assertEqual(t, attemptedExit, 3, "Should have exited ibazel")
 }
 
-func TestHandleSignals_SIGKILL(t *testing.T) {
+func TestHandleSignals_SIGTERM(t *testing.T) {
 	i := &IBazel{}
 	err := i.setup()
 	if err != nil {
@@ -356,7 +356,7 @@ func TestHandleSignals_SIGKILL(t *testing.T) {
 	i.sigs = make(chan os.Signal, 1)
 	defer i.Cleanup()
 
-	// Now test sending SIGKILL
+	// Now test sending SIGTERM
 	attemptedExit := false
 	osExit = func(i int) {
 		attemptedExit = true
@@ -367,7 +367,7 @@ func TestHandleSignals_SIGKILL(t *testing.T) {
 	cmd.Start()
 	i.cmd = cmd
 
-	i.sigs <- syscall.SIGKILL
+	i.sigs <- syscall.SIGTERM
 	i.handleSignals()
 	cmd.assertTerminated(t)
 

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -27,6 +27,7 @@ var overrideableBazelFlags []string = []string{
 
 var logToFile = flag.String("log_to_file", "-", "Log iBazel stderr to a file instead of os.Stderr")
 var noLiveReload = flag.Bool("nolive_reload", false, "Disable JavaScript live reload support")
+var profileDev = flag.Bool("profile_dev", false, "Enable development profiling")
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `iBazel
@@ -121,6 +122,7 @@ func handle(i *IBazel, command string, args []string) {
 	targets, bazelArgs, args := parseArgs(args)
 	i.SetBazelArgs(bazelArgs)
 	i.SetNoLiveReload(*noLiveReload)
+	i.SetProfileDev(*profileDev)
 
 	switch command {
 	case "build":

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -26,6 +26,7 @@ var overrideableBazelFlags []string = []string{
 }
 
 var logToFile = flag.String("log_to_file", "-", "Log iBazel stderr to a file instead of os.Stderr")
+var noLiveReload = flag.Bool("nolive_reload", false, "Disable JavaScript live reload support")
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `iBazel
@@ -35,7 +36,7 @@ target, run, build, or test the specified targets.
 
 Usage:
 
-ibazel build|test|run targets...
+ibazel [flags] build|test|run targets...
 
 Example:
 
@@ -119,6 +120,7 @@ func main() {
 func handle(i *IBazel, command string, args []string) {
 	targets, bazelArgs, args := parseArgs(args)
 	i.SetBazelArgs(bazelArgs)
+	i.SetNoLiveReload(*noLiveReload)
 
 	switch command {
 	case "build":


### PR DESCRIPTION
- Adds off-the-shelf live reload server (github.com/jaschaephraim/lrserver) that is turned on via `ibazel_live_reload` tag in run target.
- Live reload server defaults to port 35729 but ports are scanned and first available port between 35729 and 35828 (range of 100) is chosen
- Adds `-nolive_reload` flag which forces live reload server off even if `ibazel_live_reload` is set
- Adds `-profile_dev` flag which turns on profile (just console logs at the moment)
- `ibazel_live_reload` flag usage requires fix to rules_typescript on my fork: https://github.com/gregmagolan/rules_typescript/tree/devserver
