### PR TITLE
Notify of changes command: Correctly identify when a build completes

### DIFF
--- a/bazel/testing/mock.go
+++ b/bazel/testing/mock.go
@@ -27,7 +27,8 @@ type MockBazel struct {
 	queryResponse map[string]*blaze_query.QueryResult
 	args          []string
 
-	waitError error
+	buildError error
+	waitError  error
 }
 
 func (b *MockBazel) SetArguments(args []string) {
@@ -63,7 +64,10 @@ func (b *MockBazel) Query(args ...string) (*blaze_query.QueryResult, error) {
 }
 func (b *MockBazel) Build(args ...string) error {
 	b.actions = append(b.actions, append([]string{"Build"}, args...))
-	return nil
+	return b.buildError
+}
+func (b *MockBazel) BuildError(e error) {
+	b.buildError = e
 }
 func (b *MockBazel) Test(args ...string) error {
 	b.actions = append(b.actions, append([]string{"Test"}, args...))

--- a/ibazel/command/BUILD
+++ b/ibazel/command/BUILD
@@ -39,4 +39,5 @@ go_test(
         "//bazel:go_default_library",
         "//bazel/testing:go_default_library",
     ],
+    size = "small",
 )

--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -86,12 +86,7 @@ func (c *notifyCommand) NotifyOfChanges() {
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
 
-	err := b.Build(c.target)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error building target: %s\n%v", err)
-	}
-
-	res := b.Wait()
+	res := b.Build(c.target)
 	if res != nil {
 		fmt.Fprintf(os.Stderr, "FAILURE: %v\n", res)
 		_, err := c.stdin.Write([]byte("IBAZEL_BUILD_COMPLETED FAILURE\n"))

--- a/ibazel/command/notify_command_test.go
+++ b/ibazel/command/notify_command_test.go
@@ -47,14 +47,14 @@ func TestNotifyCommand(t *testing.T) {
 
 	// Mock out bazel to return non-error on test
 	b := &mock_bazel.MockBazel{}
-	b.WaitError(nil)
+	b.BuildError(nil)
 	bazelNew = func() bazel.Bazel { return b }
 	defer func() { bazelNew = oldBazelNew }()
 
 	c.NotifyOfChanges()
-	b.WaitError(errors.New("Demo error"))
+	b.BuildError(errors.New("Demo error"))
 	c.NotifyOfChanges()
-	b.WaitError(nil)
+	b.BuildError(nil)
 	c.NotifyOfChanges()
 
 	b.AssertActions(t, [][]string{


### PR DESCRIPTION
(fixes #56) Prior to this change everytime ibazel rebuilt a bazel command it
would think that the build failed even if it succeeded.
The issue was the the underlying command object was being
called with both Run()# On branch master and subsequently Wait().
Becuase the command had already been run,
the invocation of Wait() always produced an error.