### PR TITLE
Live reload

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,6 +33,18 @@ go_repository(
 )
 
 go_repository(
+    name = "com_github_gregmagolan_lrserver",
+    commit = "2e678573ccbdc2144f01a52f3219bf67cd5f0fc8",
+    importpath = "github.com/gregmagolan/lrserver",
+)
+
+go_repository(
+    name = "com_github_gorilla_websocket",
+    commit = "7ca4275b84a9d500f68971c8c4a97f0ec18eb889",
+    importpath = "github.com/gorilla/websocket",
+)
+
+go_repository(
     name = "org_golang_x_sys",
     commit = "99f16d856c9836c42d24e7ab64ea72916925fa97",
     importpath = "golang.org/x/sys",

--- a/ibazel/BUILD
+++ b/ibazel/BUILD
@@ -35,6 +35,8 @@ go_library(
         "//ibazel/command:go_default_library",
         "//third_party/bazel/master/src/main/protobuf:go_default_library",
         "@com_github_fsnotify_fsnotify//:go_default_library",
+        "@com_github_gorilla_websocket//:go_default_library",
+        "@com_github_gregmagolan_lrserver//:go_default_library",
     ],
 )
 
@@ -52,6 +54,8 @@ go_test(
         "//ibazel/command:go_default_library",
         "//third_party/bazel/master/src/main/protobuf:go_default_library",
         "@com_github_fsnotify_fsnotify//:go_default_library",
+        "@com_github_gorilla_websocket//:go_default_library",
+        "@com_github_gregmagolan_lrserver//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -16,8 +16,11 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
 	"reflect"
+	"regexp"
 	"runtime"
 	"runtime/debug"
 	"syscall"
@@ -99,6 +102,11 @@ func init() {
 						Attribute: []*blaze_query.Attribute{
 							&blaze_query.Attribute{
 								Name: proto.String("name"),
+							},
+							&blaze_query.Attribute{
+								Name:            proto.String("tags"),
+								Type:            blaze_query.Attribute_STRING_LIST.Enum(),
+								StringListValue: []string{"ibazel_live_reload"},
 							},
 						},
 					},
@@ -250,7 +258,6 @@ func TestIBazelRun_firstPass(t *testing.T) {
 	defer i.Cleanup()
 
 	i.run("//path/to:target")
-
 }
 
 func TestIBazelRun_notifyPreexistiingJobWhenStarting(t *testing.T) {
@@ -280,6 +287,41 @@ func TestIBazelRun_notifyPreexistiingJobWhenStarting(t *testing.T) {
 
 	if !cmd.notifiedOfChanges {
 		t.Errorf("The preiously running command was not notified of changes")
+	}
+}
+
+func TestIBazelRun_livereload(t *testing.T) {
+	i, err := New()
+	if err != nil {
+		t.Errorf("Error creating IBazel: %s", err)
+	}
+	defer i.Cleanup()
+
+	i.run("//path/to:target")
+
+	livereloadUrl := os.Getenv("IBAZEL_LIVERELOAD_URL")
+	validUrl := regexp.MustCompile("^http\\:\\/\\/localhost\\:[0-9]+\\/livereload\\.js\\?snipver\\=1$")
+	if !validUrl.MatchString(livereloadUrl) {
+		t.Errorf("Invalid livereload URL '%s'", livereloadUrl)
+	}
+
+	client := new(http.Client)
+	resp, err := client.Get(livereloadUrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bodyString := string(body)
+	validBodyStart := regexp.MustCompile("^\\(function e\\(t\\,n\\,r\\)")
+	validBodyEnd := regexp.MustCompile("\\}\\,\\{\\}\\]\\}\\,\\{\\}\\,\\[8\\]\\)\\;$")
+	if !validBodyStart.MatchString(bodyString) || !validBodyEnd.MatchString(bodyString) {
+		t.Errorf("Invalid livereload.js")
 	}
 }
 

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -26,8 +26,9 @@ var overrideableBazelFlags []string = []string{
 	"--test_output=",
 }
 
-var debounceDuration = flag.Duration("debounce", 100 * time.Millisecond, "Debounce duration")
+var debounceDuration = flag.Duration("debounce", 100*time.Millisecond, "Debounce duration")
 var logToFile = flag.String("log_to_file", "-", "Log iBazel stderr to a file instead of os.Stderr")
+var noLiveReload = flag.Bool("nolive_reload", false, "Disable JavaScript live reload support")
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `iBazel
@@ -37,7 +38,7 @@ target, run, build, or test the specified targets.
 
 Usage:
 
-ibazel build|test|run targets...
+ibazel [flags] build|test|run targets...
 
 Example:
 
@@ -122,6 +123,7 @@ func main() {
 func handle(i *IBazel, command string, args []string) {
 	targets, bazelArgs, args := parseArgs(args)
 	i.SetBazelArgs(bazelArgs)
+	i.SetLiveReload(!(*noLiveReload))
 
 	switch command {
 	case "build":


### PR DESCRIPTION
* Adds off-the-shelf live reload server (github.com/jaschaephraim/lrserver) that is turned on via `ibazel_live_reload` tag in `ts_devserver` run target (requires unreleased rules_typescript devserver changes for flag support).
* Live reload server defaults to port 35729; ports are scanned and first available port between 35729 and 35828 (range of 100) is chosen
* Adds `-nolive_reload` flag which forces live reload server off even if `ibazel_live_reload` is set

Original PR #69