### PR TITLE
Warn when using globally installed npm package

### DIFF
--- a/npm/index.js
+++ b/npm/index.js
@@ -54,6 +54,12 @@ function main(args) {
       break;
     }
   }
+  if (basePath === __dirname) {
+    console.error(`WARNING: no ibazel version found in your node_modules.
+        We recommend installing a devDependency on ibazel so you use the same
+        version as other engineers on this project.
+        Using the globally installed version at ${__dirname}`);
+  }
 
   const binary = path.join(basePath, 'bin', `${platform}_${arch}`, 'ibazel');
   const ibazel = spawn(binary, args, {stdio: 'inherit'});


### PR DESCRIPTION
Followup to #74
When we roll out the feature of searching for a locally installed ibazel, we need to communicate it to users,
or they are not likely to discover it.
Especially while ibazel is under active development, development workflows like browser livereload are
sensitive to the ibazel version so I want to be sure users are not likely to trip on versioning.