### PR TITLE
Add the concept of lifecycle hooks

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,9 +43,9 @@ go_repository(
 )
 
 go_repository(
-    name = "com_github_gregmagolan_lrserver",
-    commit = "2e678573ccbdc2144f01a52f3219bf67cd5f0fc8",
-    importpath = "github.com/gregmagolan/lrserver",
+    name = "com_github_jaschaephraim_lrserver",
+    commit = "50d19f603f71e0a914f23eea33124ba9717e7873",
+    importpath = "github.com/jaschaephraim/lrserver",
 )
 
 go_repository(
@@ -70,4 +70,10 @@ go_repository(
     name = "com_github_golang_protobuf",
     commit = "130e6b02ab059e7b717a096f397c5b60111cae74",
     importpath = "github.com/golang/protobuf",
+)
+
+go_repository(
+    name = "com_github_gorilla_websocket",
+    commit = "c55883f97322b4bcbf48f734e23d6ab3af1ea488",
+    importpath = "github.com/gorilla/websocket",
 )

--- a/e2e/ibazel.go
+++ b/e2e/ibazel.go
@@ -31,7 +31,7 @@ func (i *IBazelTester) bazelPath() string {
 }
 
 func (i *IBazelTester) Run(target string) {
-	i.cmd = exec.Command(ibazelPath, "--bazel_path="+i.bazelPath(), "--log_to_file=/tmp/output.log", "run", target)
+	i.cmd = exec.Command(ibazelPath, "--bazel_path="+i.bazelPath(), "--log_to_file=/tmp/ibazel_output.log", "run", target)
 
 	errCode, buildStdout, buildStderr := i.bazel.RunBazel([]string{"build", target})
 	if errCode != 0 {

--- a/e2e/live_reload/BUILD
+++ b/e2e/live_reload/BUILD
@@ -1,0 +1,18 @@
+# gazelle:exclude live_reload_test.go
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@com_github_bazelbuild_bazel_integration_testing//go:bazel_integration_test.bzl", "bazel_go_integration_test")
+
+bazel_go_integration_test(
+    name = "go_default_test",
+    srcs = ["live_reload_test.go"],
+    data = [
+        "//ibazel",
+    ],
+    importpath = "github.com/bazelbuild/bazel-watcher/e2e/live_reload",
+    deps = [
+        "//e2e:go_default_library",
+        "@com_github_bazelbuild_bazel_integration_testing//go:go_default_library",
+        "@com_github_gorilla_websocket//:go_default_library",
+    ],
+)

--- a/e2e/live_reload/live_reload_test.go
+++ b/e2e/live_reload/live_reload_test.go
@@ -1,0 +1,137 @@
+package live_reload
+
+import (
+	"net/url"
+	"reflect"
+	"runtime/debug"
+	"strings"
+	"testing"
+	"time"
+
+	bazel "github.com/bazelbuild/bazel-integration-testing/go"
+	"github.com/bazelbuild/bazel-watcher/e2e"
+	"github.com/gorilla/websocket"
+)
+
+type liveReloadHello struct {
+	Command   string   `json:"command"`
+	Protocols []string `json:"protocols"`
+}
+
+const printLivereload = `printf "Live reload url: ${IBAZEL_LIVERELOAD_URL}"`
+
+func sleep() {
+	time.Sleep(5 * time.Second)
+}
+
+func must(t *testing.T, e error) {
+	if e != nil {
+		t.Errorf("Error: %s", e)
+		debug.PrintStack()
+	}
+}
+
+func assertNotEqual(t *testing.T, want, got interface{}, msg string) {
+	if reflect.DeepEqual(want, got) {
+		t.Errorf("Wanted %s, got %s. %s", want, got, msg)
+		debug.PrintStack()
+	}
+}
+func assertEqual(t *testing.T, want, got interface{}, msg string) {
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("Wanted [%v], got [%v]. %s", want, got, msg)
+		debug.PrintStack()
+	}
+}
+
+func verify(t *testing.T, conn *websocket.Conn, expected interface{}) {
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+
+	_, v, err := conn.ReadMessage()
+	m := strings.TrimSpace(string(v))
+	t.Logf("v: %s, err: %s\n", m, err)
+	if err != nil {
+		t.Errorf("Error ReadJSONing from websocket: %s", err)
+	}
+
+	assertEqual(t, expected, m, "Expected response match")
+}
+
+func TestLiveReload(t *testing.T) {
+	b, err := bazel.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	must(t, b.ScratchFile("WORKSPACE", ""))
+	must(t, b.ScratchFileWithMode("test.sh", printLivereload, 0777))
+	must(t, b.ScratchFile("test.txt", "1"))
+	must(t, b.ScratchFile("BUILD", `
+sh_binary(
+	name = "live_reload",
+	srcs = ["test.sh"],
+	data = ["test.txt"],
+	tags = ["ibazel_live_reload"],
+)
+`))
+
+	ibazel := e2e.NewIBazelTester(b)
+	ibazel.Run("//:live_reload")
+	defer ibazel.Kill()
+
+	sleep()
+	out := ibazel.GetOutput()
+	t.Logf("Output: '%s'", out)
+	url, err := url.ParseRequestURI(out[len("Live reload url: "):])
+	if err != nil {
+		t.Error(err)
+	}
+
+	wsUrl := "ws://" + url.Hostname() + ":" + url.Port() + "/livereload"
+	t.Logf("wsUrl: %s", wsUrl)
+	conn, _, err := websocket.DefaultDialer.Dial(wsUrl, map[string][]string{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Send the hello message to the client.
+	hello := liveReloadHello{
+		Command:   "hello",
+		Protocols: []string{"http://livereload.com/protocols/official-7"},
+	}
+	if err = conn.WriteJSON(hello); err != nil {
+		t.Error(err)
+	}
+
+	// Verify the hello message
+	verify(t, conn, `{"command":"hello","protocols":["http://livereload.com/protocols/official-7","http://livereload.com/protocols/official-8","http://livereload.com/protocols/official-9","http://livereload.com/protocols/2.x-origin-version-negotiation","http://livereload.com/protocols/2.x-remote-control"],"serverName":"live reload"}`)
+
+	must(t, b.ScratchFile("test.txt", "2"))
+	sleep()
+	verify(t, conn, `{"command":"reload","path":"reload","liveCSS":true}`)
+
+	must(t, b.ScratchFile("test.txt", "3"))
+	sleep()
+	verify(t, conn, `{"command":"reload","path":"reload","liveCSS":true}`)
+}
+
+func TestNoLiveReload(t *testing.T) {
+	b, err := bazel.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	must(t, b.ScratchFile("WORKSPACE", ""))
+	must(t, b.ScratchFileWithMode("test.sh", printLivereload, 0777))
+	must(t, b.ScratchFile("BUILD", `
+sh_binary(
+	name = "no_live_reload",
+	srcs = ["test.sh"],
+)
+`))
+
+	ibazel := e2e.NewIBazelTester(b)
+	ibazel.Run("//:no_live_reload")
+	defer ibazel.Kill()
+
+	sleep()
+	assertEqual(t, ibazel.GetOutput(), "Live reload url: ", "Expected there to be no output but got some")
+}

--- a/ibazel/BUILD
+++ b/ibazel/BUILD
@@ -31,6 +31,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "ibazel.go",
+        "lifecycle.go",
         "main.go",
         "source_event_handler.go",
     ],
@@ -39,9 +40,9 @@ go_library(
     deps = [
         "//bazel:go_default_library",
         "//ibazel/command:go_default_library",
+        "//ibazel/live_reload:go_default_library",
         "//third_party/bazel/master/src/main/protobuf:go_default_library",
         "@com_github_fsnotify_fsnotify//:go_default_library",
-        "@com_github_gregmagolan_lrserver//:go_default_library",
     ],
 )
 

--- a/ibazel/command/command.go
+++ b/ibazel/command/command.go
@@ -30,7 +30,7 @@ var bazelNew = bazel.New
 // Command is an object that wraps the logic of running a task in Bazel and
 // manipulating it.
 type Command interface {
-	Start()
+	Start() error
 	Terminate()
 	NotifyOfChanges()
 	IsSubprocessRunning() bool

--- a/ibazel/command/default_command.go
+++ b/ibazel/command/default_command.go
@@ -54,7 +54,7 @@ func (c *defaultCommand) Terminate() {
 	c.cmd = nil
 }
 
-func (c *defaultCommand) Start() {
+func (c *defaultCommand) Start() error {
 	b := bazelNew()
 	b.SetArguments(c.bazelArgs)
 
@@ -68,8 +68,10 @@ func (c *defaultCommand) Start() {
 	var err error
 	if err = c.cmd.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error starting process: %v\n", err)
+		return err
 	}
 	fmt.Fprintf(os.Stderr, "Starting...")
+	return nil
 }
 
 func (c *defaultCommand) NotifyOfChanges() {

--- a/ibazel/command/default_command.go
+++ b/ibazel/command/default_command.go
@@ -63,6 +63,8 @@ func (c *defaultCommand) Start() {
 
 	c.cmd = start(b, c.target, c.args)
 
+	c.cmd.Env = os.Environ()
+
 	var err error
 	if err = c.cmd.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error starting process: %v\n", err)

--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -56,7 +56,7 @@ func (c *notifyCommand) Terminate() {
 	c.cmd = nil
 }
 
-func (c *notifyCommand) Start() {
+func (c *notifyCommand) Start() error {
 	b := bazelNew()
 	b.SetArguments(c.bazelArgs)
 
@@ -69,14 +69,17 @@ func (c *notifyCommand) Start() {
 	c.stdin, err = c.cmd.StdinPipe()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error getting stdin pipe: %v\n", err)
+		return err
 	}
 
 	c.cmd.Env = append(os.Environ(), "IBAZEL_NOTIFY_CHANGES=y")
 
 	if err = c.cmd.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error starting process: %v\n", err)
+		return err
 	}
 	fmt.Fprintf(os.Stderr, "Starting...")
+	return nil
 }
 
 func (c *notifyCommand) NotifyOfChanges() {

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -54,11 +54,12 @@ type mockCommand struct {
 	terminated        bool
 }
 
-func (m *mockCommand) Start() {
+func (m *mockCommand) Start() error {
 	if m.started {
 		panic("Can't run command twice")
 	}
 	m.started = true
+	return nil
 }
 func (m *mockCommand) NotifyOfChanges() {
 	m.notifiedOfChanges = true
@@ -157,8 +158,9 @@ func TestIBazelLoop(t *testing.T) {
 
 	// First let's consume all the events from all the channels we care about
 	called := false
-	command := func(targets ...string) {
+	command := func(targets ...string) error {
 		called = true
+		return nil
 	}
 
 	i.state = QUERY

--- a/ibazel/lifecycle.go
+++ b/ibazel/lifecycle.go
@@ -7,19 +7,26 @@ import (
 // Lifecycle is an object that listens to the lifecycle events of iBazel and
 // behaves appropriately..
 type Lifecycle interface {
+	// Initialize is called once it is known that this lifecycle client is going
+	// to be used.
+	Initialize()
+
 	// TargetDecider takes a protobuf rule and performs setup if it matches the
 	// listener's expectations.
 	TargetDecider(rule *blaze_query.Rule)
 
-	// Setup is called once it is known that this lifesycle client is going to be
-	// used. You can call methods on the ibazel object in this context to set
-	// additional environment variables to be passed into the client or to
-	// retrigger action.
-	Setup()
+	// ChangeDetected is called when a change is detected
+	// changeType: "source"|"graph"
+	ChangeDetected(changeType string)
+
 	// Cleanup is your opportunity to clean up open sockets or connections.
 	Cleanup()
 
-	// Before running an "event" where name = (build|test|run).
-	BeforeEvent(string)
-	AfterEvent(string)
+	// BeforeCommand is called before a blaze $COMMAND is run.
+	// command: "build"|"test"|"run"
+	BeforeCommand(command string)
+	// AfterCommand is called after a blaze $COMMAND is run with the result of
+	// that command.
+	// command: "build"|"test"|"run"
+	AfterCommand(command string, success bool)
 }

--- a/ibazel/lifecycle.go
+++ b/ibazel/lifecycle.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"github.com/bazelbuild/bazel-watcher/third_party/bazel/master/src/main/protobuf"
+)
+
+// Lifecycle is an object that listens to the lifecycle events of iBazel and
+// behaves appropriately..
+type Lifecycle interface {
+	// TargetDecider takes a protobuf rule and performs setup if it matches the
+	// listener's expectations.
+	TargetDecider(rule *blaze_query.Rule)
+
+	// Setup is called once it is known that this lifesycle client is going to be
+	// used. You can call methods on the ibazel object in this context to set
+	// additional environment variables to be passed into the client or to
+	// retrigger action.
+	Setup()
+	// Cleanup is your opportunity to clean up open sockets or connections.
+	Cleanup()
+
+	// Before running an "event" where name = (build|test|run).
+	BeforeEvent(string)
+	AfterEvent(string)
+}

--- a/ibazel/live_reload/BUILD.bazel
+++ b/ibazel/live_reload/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["server.go"],
+    importpath = "github.com/bazelbuild/bazel-watcher/ibazel/live_reload",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//third_party/bazel/master/src/main/protobuf:go_default_library",
+        "@com_github_jaschaephraim_lrserver//:go_default_library",
+    ],
+)

--- a/ibazel/live_reload/server.go
+++ b/ibazel/live_reload/server.go
@@ -36,7 +36,7 @@ func New() *LiveReloadServer {
 	return &LiveReloadServer{}
 }
 
-func (l *LiveReloadServer) Setup() {}
+func (l *LiveReloadServer) Initialize() {}
 
 func (l *LiveReloadServer) startLiveReloadServer() {
 	if l.lrserver != nil {
@@ -62,7 +62,11 @@ func (l *LiveReloadServer) startLiveReloadServer() {
 	}
 	fmt.Fprintf(os.Stderr, "Could not find open port for live reload server\n")
 }
-func (l *LiveReloadServer) Cleanup() {}
+func (l *LiveReloadServer) Cleanup() {
+	if l.lrserver != nil {
+		l.lrserver.Close()
+	}
+}
 
 func (l *LiveReloadServer) TargetDecider(rule *blaze_query.Rule) {
 	for _, attr := range rule.Attribute {
@@ -87,8 +91,10 @@ func contains(l []string, e string) bool {
 	return false
 }
 
-func (l *LiveReloadServer) BeforeEvent(name string) {}
-func (l *LiveReloadServer) AfterEvent(name string) {
+func (l *LiveReloadServer) ChangeDetected(changeType string) {}
+
+func (l *LiveReloadServer) BeforeCommand(command string) {}
+func (l *LiveReloadServer) AfterCommand(command string, success bool) {
 	if l.lrserver != nil {
 		fmt.Fprintf(os.Stderr, "Triggering live reload\n")
 		l.lrserver.Reload("reload")

--- a/ibazel/live_reload/server.go
+++ b/ibazel/live_reload/server.go
@@ -1,0 +1,108 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package live_reload
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strconv"
+
+	blaze_query "github.com/bazelbuild/bazel-watcher/third_party/bazel/master/src/main/protobuf"
+	"github.com/jaschaephraim/lrserver"
+)
+
+var noLiveReload = flag.Bool("nolive_reload", false, "Disable JavaScript live reload support")
+
+type LiveReloadServer struct {
+	lrserver *lrserver.Server
+}
+
+func New() *LiveReloadServer {
+	return &LiveReloadServer{}
+}
+
+func (l *LiveReloadServer) Setup() {}
+
+func (l *LiveReloadServer) startLiveReloadServer() {
+	if l.lrserver != nil {
+		return
+	}
+
+	port := lrserver.DefaultPort
+	for ; port < lrserver.DefaultPort+100; port++ {
+		if testPort(port) {
+			l.lrserver = lrserver.New("live reload", port)
+			// Live reload server shouldn't log.
+			l.lrserver.SetStatusLog(log.New(os.Stderr, "", 0))
+			go func() {
+				err := l.lrserver.ListenAndServe()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Live reload server failed to start: %v\n", err)
+				}
+			}()
+			url := fmt.Sprintf("http://localhost:%d/livereload.js?snipver=1", port)
+			os.Setenv("IBAZEL_LIVERELOAD_URL", url)
+			return
+		}
+	}
+	fmt.Fprintf(os.Stderr, "Could not find open port for live reload server\n")
+}
+func (l *LiveReloadServer) Cleanup() {}
+
+func (l *LiveReloadServer) TargetDecider(rule *blaze_query.Rule) {
+	for _, attr := range rule.Attribute {
+		if *attr.Name == "tags" && *attr.Type == blaze_query.Attribute_STRING_LIST {
+			if contains(attr.StringListValue, "ibazel_live_reload") {
+				if *noLiveReload {
+					fmt.Fprintf(os.Stderr, "Target requests live_reload but liveReload has been disabled with the -nolive_reload flag.\n")
+					return
+				}
+				l.startLiveReloadServer()
+				return
+			}
+		}
+	}
+}
+func contains(l []string, e string) bool {
+	for _, i := range l {
+		if i == e {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *LiveReloadServer) BeforeEvent(name string) {}
+func (l *LiveReloadServer) AfterEvent(name string) {
+	if l.lrserver != nil {
+		fmt.Fprintf(os.Stderr, "Triggering live reload\n")
+		l.lrserver.Reload("reload")
+	}
+}
+
+func testPort(port uint16) bool {
+	ln, err := net.Listen("tcp", ":"+strconv.FormatInt(int64(port), 10))
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Port %d: %v\n", port, err)
+		return false
+	}
+
+	ln.Close()
+	return true
+}

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -30,7 +30,6 @@ var overrideableBazelFlags []string = []string{
 
 var debounceDuration = flag.Duration("debounce", 100*time.Millisecond, "Debounce duration")
 var logToFile = flag.String("log_to_file", "-", "Log iBazel stderr to a file instead of os.Stderr")
-var noLiveReload = flag.Bool("nolive_reload", false, "Disable JavaScript live reload support")
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `iBazel - Version %s
@@ -125,7 +124,6 @@ func main() {
 func handle(i *IBazel, command string, args []string) {
 	targets, bazelArgs, args := parseArgs(args)
 	i.SetBazelArgs(bazelArgs)
-	i.SetLiveReload(!(*noLiveReload))
 
 	switch command {
 	case "build":


### PR DESCRIPTION
Also migrate livereload into being the first consumer of these lifecycle
hooks. This should allow the core of iBazel to be relatively simple but
additional modules be made available to the end user in any boolean
combination.

I'm open and supportive of adding more hooks into the lifecycle of an
iBazel session. If there is something you would like to see hooked, add
it to the Lifecycle interface with a before/after version.