### PR TITLE
Move CI configuration into bazel.rc

### DIFF
--- a/.ci/bazel-watcher.json
+++ b/.ci/bazel-watcher.json
@@ -1,0 +1,26 @@
+// This file is a relaxed subset of JSON so it can have comments. For more
+// config examples see:
+// https://github.com/bazelbuild/continuous-integration/tree/master/jenkins/jobs/configs
+[
+  {
+    "product": "bazel-watcher",
+    "configurations": [
+      {
+        "variation": "",
+        "configurations": [
+          {"node": "linux-x86_64"},
+          {"node": "ubuntu_16.04-x86_64"},
+          {"node": "darwin-x86_64"}
+        ]
+      }
+    ],
+    "parameters": {
+      "targets": ["//..."],
+      "test_opts": ["--config=ci"],
+      "build_opts": ["--config=ci"],
+      "tests": ["//..."]
+    }
+  }
+]
+
+

--- a/.test-bazelrc
+++ b/.test-bazelrc
@@ -1,4 +1,0 @@
-# This file contains options passed to Bazel when running tests.
-# They are used by Travis CI and by non-Bazel test scripts.
-build --verbose_failures --sandbox_debug --test_output=errors --spawn_strategy=standalone --genrule_strategy=standalone
-test --test_strategy=standalone

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 # trusty beta image has jdk8, gcc4.8.4
 dist: trusty
 sudo: required
-# xcode8 has jdk8
+# xcode8 has JDK8 and bazel isn't JDK9 compatable yet.
+# https://github.com/bazelbuild/bazel/issues/3410
 osx_image: xcode8
 # Not technically required but suppresses 'Ruby' in Job status message.
 language: java
@@ -11,7 +12,7 @@ os:
   - osx
 
 env:
-  - V=0.8.0
+  - V=0.8.1
 
 before_install:
   - |
@@ -46,15 +47,9 @@ before_install:
 script:
   - |
     bazel \
-      --output_base=$HOME/.cache/bazel \
-      --batch \
-      --host_jvm_args=-Xmx500m \
-      --host_jvm_args=-Xms500m \
-      --bazelrc=.test-bazelrc \
       test \
-      --experimental_repository_cache="$HOME/.bazel_repository_cache" \
-      --local_resources=400,1,1.0 \
-      --test_tag_filters=-dev \
+      --config=travis \
+      --config=ci \
       //...
 
 notifications:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,7 +22,7 @@ load("@com_github_bazelbuild_bazel_integration_testing//tools:repositories.bzl",
 
 bazel_binaries()
 
-rules_go_commit = "f80dec7889568c36eb191d3d1534d2db4574d430"
+rules_go_commit = "dea7cd17fe34744e28e6926feb9efb27ae665b18"
 
 git_repository(
     name = "io_bazel_rules_go",
@@ -68,7 +68,7 @@ go_repository(
 
 go_repository(
     name = "com_github_golang_protobuf",
-    commit = "130e6b02ab059e7b717a096f397c5b60111cae74",
+    commit = "1e59b77b52bf8e4b449a57e6f79f21226d571845",
     importpath = "github.com/golang/protobuf",
 )
 

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,5 +1,21 @@
 build --workspace_status_command=tools/workplace_status.sh
 
+# Flags used by Jenkins CI
+build:ci --verbose_failures
+build:travis --sandbox_debug
+build:travis --test_output=errors
+build:travis --spawn_strategy=standalone
+build:travis --genrule_strategy=standalone
+build:travis --test_strategy=standalone
+
+# Flags specific to TravisCI (used in conjunction with the :ci flags)
+startup:travis --output_base=/home/travis/.cache/bazel
+#startup:travis --batch
+startup:travis --host_jvm_args=-Xmx500m
+startup:travis --host_jvm_args=-Xms500m
+test:travis --experimental_repository_cache="/home/travis/.bazel_repository_cache"
+test:travis --local_resources=400,1,1.0
+
 # Flags used during releases
 build:release --stamp
 test:release --stamp


### PR DESCRIPTION
Also bring the configuration for Bazel CI inhouse. This will allow us to
turn on Windows CI when we are ready.