### PR TITLE
Move NPM generation into Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,7 +22,7 @@ load("@com_github_bazelbuild_bazel_integration_testing//tools:repositories.bzl",
 
 bazel_binaries()
 
-rules_go_commit = "f80dec7889568c36eb191d3d1534d2db4574d430"
+rules_go_commit = "dea7cd17fe34744e28e6926feb9efb27ae665b18"
 
 git_repository(
     name = "io_bazel_rules_go",
@@ -56,7 +56,7 @@ go_repository(
 
 go_repository(
     name = "org_golang_x_sys",
-    commit = "99f16d856c9836c42d24e7ab64ea72916925fa97",
+    commit = "571f7bbbe08da2a8955aed9d4db316e78630e9a3",
     importpath = "golang.org/x/sys",
 )
 

--- a/ibazel/BUILD
+++ b/ibazel/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//:os.bzl", "OSES")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_binary")
 
 go_binary(
@@ -34,10 +35,10 @@ go_library(
         "lifecycle.go",
         "main.go",
         "source_event_handler.go",
-        "workspace_finder.go"
+        "workspace_finder.go",
     ],
     importpath = "github.com/bazelbuild/bazel-watcher/ibazel",
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
     deps = [
         "//bazel:go_default_library",
         "//ibazel/command:go_default_library",

--- a/npm/BUILD
+++ b/npm/BUILD
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//:os.bzl", "OSES")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 genrule(
@@ -20,10 +22,10 @@ genrule(
         "//:CONTRIBUTORS",
     ],
     outs = ["package.json"],
-    cmd = "$(location :npm) $(location //:CONTRIBUTORS) > $@",
+    cmd = "$(location :package_generator) $(location //:CONTRIBUTORS) > $@",
     stamp = 1,
     tools = [
-        ":npm",
+        ":package_generator",
     ],
 )
 
@@ -35,11 +37,65 @@ go_library(
 )
 
 go_binary(
-    name = "npm",
+    name = "package_generator",
     embed = [":go_default_library"],
     importpath = "github.com/bazelbuild/bazel-watcher/npm",
     visibility = ["//visibility:public"],
     x_defs = {
         "main.Version": "{STABLE_GIT_VERSION}",
     },
+)
+
+genrule(
+    name = "index_for_oses",
+    srcs = ["index.tpl.js"],
+    outs = ["index.js"],
+    cmd = """
+        sed -e 's|__OSES__|%s|' $(location :index.tpl.js) > $(location :index.js)
+    """ % ("\", ".join(OSES)),
+)
+
+pkg_tar(
+    name = "npm_tar",
+    srcs = [
+        ":index.js",
+        ":package.json",
+    ],
+    mode = "0644",
+    package_dir = "/",
+    strip_prefix = "/npm",
+)
+
+[go_binary(
+    name = "ibazel_%s" % GOOS,
+    embed = ["//ibazel:go_default_library"],
+    goos = GOOS,
+    importpath = "github.com/bazelbuild/bazel-watcher/ibazel",
+    # Since we don't have any cgo dependencies, force build to be pure
+    # golang. This will make multi-os compatability *MUCH* easier.
+    pure = "on",
+    visibility = ["//visibility:private"],
+    x_defs = {
+        "main.Version": "{STABLE_GIT_VERSION}",
+    },
+) for GOOS in OSES]
+
+[pkg_tar(
+    name = "%s_tar" % GOOS,
+    srcs = [":ibazel_%s" % GOOS],
+    mode = "0755",
+    package_dir = "/bin/%s_amd64" % GOOS,
+    strip_prefix = "/ibazel/%s_amd64_pure_stripped" % GOOS,
+) for GOOS in OSES]
+
+pkg_tar(
+    name = "npm",
+    extension = "tar",
+    package_dir = "/",
+    deps = [
+        ":npm_tar",
+    ] + [
+        "%s_tar" % GOOS
+        for GOOS in OSES
+    ],
 )

--- a/npm/publish.sh
+++ b/npm/publish.sh
@@ -23,50 +23,12 @@ cd "$(git rev-parse --show-toplevel)"
 # Clean the repo to make sure nothing strange is happening.
 bazel clean --expunge
 
-# Make a temporary directory to stage the release in.
-readonly STAGING="$(mktemp -d)"
-echo "Staging into ${STAGING}"
-
-# Copy over the base files required for NPM
-cp "README.md" "${STAGING}/README.md"
-cp "npm/index.js" "${STAGING}/index.js"
-bazel build --config=release "//npm:package.json"
-cp "$(bazel info bazel-genfiles)/npm/package.json" "${STAGING}/package.json"
-
-compile() {
-  export GOOS=$1; shift
-  export GOARCH=$1; shift
-
-  mkdir -p "${STAGING}/bin/${GOOS}_${GOARCH}/"
-  DESTINATION="${STAGING}/bin/${GOOS}_${GOARCH}/ibazel"
-  if [[ "${GOOS}" == "windows" ]]; then
-    DESTINATION="${DESTINATION}.exe"
-  fi
-  bazel build \
-    --config=release \
-    "--experimental_platforms=@io_bazel_rules_go//go/toolchain:${GOOS}_${GOARCH}" \
-    "//ibazel:ibazel"
-  SOURCE="$(bazel info bazel-bin)/ibazel/${GOOS}_${GOARCH}_pure_stripped/ibazel"
-  cp "${SOURCE}" "${DESTINATION}"
-
-  # Sometimes bazel likes to change the ouput directory for binaries
-  # depending on command line flags (platforms for example). In order to
-  # make this an easy to detect error, force remove the binary that was
-  # generated for this platform so that if future bazel build runs for a
-  # different architecture write to a different folder the expected
-  # directory will not exist.
-  rm -f "${SOURCE}"
-}
-
-# Now compiler ibazel for every platform/arch that is supported.
-compile "linux"   "amd64"
-compile "darwin"  "amd64"
-# Windows isn't compatable due to the os.Setpgid call.
-#compile "windows" "amd64"
+echo "Building package for NPM..."
+bazel build --config=release "//npm:npm"
 echo "Build successful."
 
 echo -n "Publishing ${STAGING} to NPM as "
-grep "version" < "${STAGING}/package.json"
+grep "version" < "$(bazel info bazel-genfiles)/npm/package.json"
 
-# Everything is staged now, actually upload the package.
-cd "$STAGING" && npm publish
+# Time to publish...
+npm publish "$(bazel info bazel-bin)/npm/npm.tar"

--- a/os.bzl
+++ b/os.bzl
@@ -1,0 +1,6 @@
+# List of OSes that are supported by iBazel
+OSES = [
+    "linux",
+    "darwin",
+    #"windows",
+]


### PR DESCRIPTION
Using rules_pkg generate the tar file that is expected by NPM in Bazel.