### PR TITLE
Output Runner and Multiple Runs

### DIFF
--- a/bazel/bazel.go
+++ b/bazel/bazel.go
@@ -207,7 +207,7 @@ func (b *bazel) Test(args ...string) (*bytes.Buffer, error) {
 func (b *bazel) Run(args ...string) (*exec.Cmd, *bytes.Buffer, error) {
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
-	stdoutBuffer, stderrBuffer := b.newCommand("run", args...)
+	stdoutBuffer, stderrBuffer := b.newCommand("run", append(b.args, args...)...)
 	b.cmd.Stdin = os.Stdin
 
 	_, _ = stdoutBuffer.Write(stderrBuffer.Bytes())

--- a/bazel/bazel_test.go
+++ b/bazel/bazel_test.go
@@ -15,6 +15,8 @@
 package bazel
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -49,36 +51,38 @@ KEY3: value`)
 
 func TestWriteToStderrAndStdout(t *testing.T) {
 	b := &bazel{}
+	stdoutBuffer := new(bytes.Buffer)
+	stderrBuffer := new(bytes.Buffer)
 
 	// By default it should write to its own pipe.
 	b.newCommand("version")
-	if b.cmd.Stdout == os.Stdout {
-		t.Errorf("Set stdout to os.Stdout")
+	if reflect.DeepEqual(b.cmd.Stdout, io.MultiWriter(os.Stdout, stderrBuffer)) {
+		t.Errorf("Set stdout to os.Stdout and stderrBuffer")
 	}
-	if b.cmd.Stderr == os.Stderr {
-		t.Errorf("Set stderr to os.Stderr")
+	if reflect.DeepEqual(b.cmd.Stderr, io.MultiWriter(os.Stderr, stdoutBuffer)) {
+		t.Errorf("Set stderr to os.Stderr and stdoutBuffer")
 	}
 
 	// If set to true it should write to the os version
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
 	b.newCommand("version")
-	if b.cmd.Stdout != os.Stdout {
-		t.Errorf("Didn't set stdout to os.Stdout")
+	if !reflect.DeepEqual(b.cmd.Stdout, io.MultiWriter(os.Stdout, stderrBuffer)) {
+		t.Errorf("Didn't set stdout to os.Stdout and stderrBuffer")
 	}
-	if b.cmd.Stderr != os.Stderr {
-		t.Errorf("Didn't set stderr to os.Stderr")
+	if !reflect.DeepEqual(b.cmd.Stderr, io.MultiWriter(os.Stderr, stdoutBuffer)) {
+		t.Errorf("Didn't set stderr to os.Stderr and stdoutBuffer")
 	}
 
 	// If set to false it should not write to the os version
 	b.WriteToStderr(false)
 	b.WriteToStdout(false)
 	b.newCommand("version")
-	if b.cmd.Stdout == os.Stdout {
-		t.Errorf("Set stdout to os.Stdout")
+	if reflect.DeepEqual(b.cmd.Stdout, io.MultiWriter(os.Stdout, stderrBuffer)) {
+		t.Errorf("Set stdout to os.Stdout and stderrBuffer")
 	}
-	if b.cmd.Stderr == os.Stderr {
-		t.Errorf("Set stderr to os.Stderr")
+	if reflect.DeepEqual(b.cmd.Stderr, io.MultiWriter(os.Stderr, stdoutBuffer)) {
+		t.Errorf("Set stderr to os.Stderr and stdoutBuffer")
 	}
 }
 

--- a/bazel/testing/mock.go
+++ b/bazel/testing/mock.go
@@ -15,6 +15,7 @@
 package testing
 
 import (
+	"bytes"
 	"os/exec"
 	"regexp"
 	"testing"
@@ -62,20 +63,20 @@ func (b *MockBazel) Query(args ...string) (*blaze_query.QueryResult, error) {
 
 	return res, nil
 }
-func (b *MockBazel) Build(args ...string) error {
+func (b *MockBazel) Build(args ...string) (*bytes.Buffer, error) {
 	b.actions = append(b.actions, append([]string{"Build"}, args...))
-	return b.buildError
+	return nil, b.buildError
 }
 func (b *MockBazel) BuildError(e error) {
 	b.buildError = e
 }
-func (b *MockBazel) Test(args ...string) error {
+func (b *MockBazel) Test(args ...string) (*bytes.Buffer, error) {
 	b.actions = append(b.actions, append([]string{"Test"}, args...))
-	return nil
-}
-func (b *MockBazel) Run(args ...string) (*exec.Cmd, error) {
-	b.actions = append(b.actions, append([]string{"Run"}, args...))
 	return nil, nil
+}
+func (b *MockBazel) Run(args ...string) (*exec.Cmd, *bytes.Buffer, error) {
+	b.actions = append(b.actions, append([]string{"Run"}, args...))
+	return nil, nil, nil
 }
 func (b *MockBazel) WaitError(e error) {
 	b.waitError = e

--- a/ibazel/command/command.go
+++ b/ibazel/command/command.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -30,15 +31,15 @@ var bazelNew = bazel.New
 // Command is an object that wraps the logic of running a task in Bazel and
 // manipulating it.
 type Command interface {
-	Start() error
+	Start() (*bytes.Buffer, error)
 	Terminate()
-	NotifyOfChanges()
+	NotifyOfChanges() *bytes.Buffer
 	IsSubprocessRunning() bool
 }
 
 // start will be called by most implementations since this logic is extremely
 // common.
-func start(b bazel.Bazel, target string, args []string) *exec.Cmd {
+func start(b bazel.Bazel, target string, args []string) (*bytes.Buffer, *exec.Cmd) {
 	tmpfile, err := ioutil.TempFile("", "bazel_script_path")
 	if err != nil {
 		fmt.Print(err)
@@ -49,7 +50,7 @@ func start(b bazel.Bazel, target string, args []string) *exec.Cmd {
 	}
 
 	// Start by building the binary
-	b.Run("--script_path="+tmpfile.Name(), target)
+	_, outputBuffer, _ := b.Run("--script_path="+tmpfile.Name(), target)
 
 	runScriptPath := tmpfile.Name()
 
@@ -62,7 +63,7 @@ func start(b bazel.Bazel, target string, args []string) *exec.Cmd {
 	// Set a process group id (PGID) on the subprocess. This is
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	return cmd
+	return outputBuffer, cmd
 }
 
 func subprocessRunning(cmd *exec.Cmd) bool {

--- a/ibazel/command/command.go
+++ b/ibazel/command/command.go
@@ -31,15 +31,15 @@ var bazelNew = bazel.New
 // Command is an object that wraps the logic of running a task in Bazel and
 // manipulating it.
 type Command interface {
-	Start() (*bytes.Buffer, error)
+	Start(logFile *os.File) (*bytes.Buffer, error)
 	Terminate()
-	NotifyOfChanges() *bytes.Buffer
+	NotifyOfChanges(logFile *os.File) *bytes.Buffer
 	IsSubprocessRunning() bool
 }
 
 // start will be called by most implementations since this logic is extremely
 // common.
-func start(b bazel.Bazel, target string, args []string) (*bytes.Buffer, *exec.Cmd) {
+func start(b bazel.Bazel, target string, args []string, logFile *os.File) (*bytes.Buffer, *exec.Cmd) {
 	tmpfile, err := ioutil.TempFile("", "bazel_script_path")
 	if err != nil {
 		fmt.Print(err)
@@ -57,8 +57,13 @@ func start(b bazel.Bazel, target string, args []string) (*bytes.Buffer, *exec.Cm
 	// Now that we have built the target, construct a executable form of it for
 	// execution in a go routine.
 	cmd := execCommand(runScriptPath, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	if logFile != nil {
+		cmd.Stdout = logFile
+		cmd.Stderr = logFile
+	} else {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
 
 	// Set a process group id (PGID) on the subprocess. This is
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/ibazel/command/default_command.go
+++ b/ibazel/command/default_command.go
@@ -55,14 +55,14 @@ func (c *defaultCommand) Terminate() {
 	c.cmd = nil
 }
 
-func (c *defaultCommand) Start() (*bytes.Buffer, error) {
+func (c *defaultCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 	b := bazelNew()
 	b.SetArguments(c.bazelArgs)
 
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
 
-	outputBuffer, foo := start(b, c.target, c.args)
+	outputBuffer, foo := start(b, c.target, c.args, logFile)
 	c.cmd = foo
 
 	c.cmd.Env = os.Environ()
@@ -76,10 +76,10 @@ func (c *defaultCommand) Start() (*bytes.Buffer, error) {
 	return outputBuffer, nil
 }
 
-func (c *defaultCommand) NotifyOfChanges() *bytes.Buffer {
+func (c *defaultCommand) NotifyOfChanges(logFile *os.File) *bytes.Buffer {
 	c.Terminate()
-	c.Start()
-	return nil
+	outputBuffer, _ := c.Start(logFile)
+	return outputBuffer
 }
 
 func (c *defaultCommand) IsSubprocessRunning() bool {

--- a/ibazel/command/default_command_test.go
+++ b/ibazel/command/default_command_test.go
@@ -50,7 +50,7 @@ func TestDefaultCommand(t *testing.T) {
 	}
 
 	// This is synonymous with killing the job so use it to kill the job and test everything.
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	assertKilled(t, toKill)
 }
 
@@ -63,7 +63,7 @@ func TestDefaultCommand_Start(t *testing.T) {
 
 	b := &mock_bazel.MockBazel{}
 
-	cmd := start(b, "//path/to:target", []string{"moo"})
+	_, cmd := start(b, "//path/to:target", []string{"moo"}, nil)
 	cmd.Start()
 
 	if cmd.Stdout != os.Stdout {

--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -57,14 +57,14 @@ func (c *notifyCommand) Terminate() {
 	c.cmd = nil
 }
 
-func (c *notifyCommand) Start() (*bytes.Buffer, error) {
+func (c *notifyCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 	b := bazelNew()
 	b.SetArguments(c.bazelArgs)
 
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
 
-	outputBuffer, foo := start(b, c.target, c.args)
+	outputBuffer, foo := start(b, c.target, c.args, logFile)
 	c.cmd = foo
 	// Keep the writer around.
 	var err error
@@ -84,7 +84,7 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 	return outputBuffer, nil
 }
 
-func (c *notifyCommand) NotifyOfChanges() *bytes.Buffer {
+func (c *notifyCommand) NotifyOfChanges(logFile *os.File) *bytes.Buffer {
 	b := bazelNew()
 	b.SetArguments(c.bazelArgs)
 

--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -56,40 +57,41 @@ func (c *notifyCommand) Terminate() {
 	c.cmd = nil
 }
 
-func (c *notifyCommand) Start() error {
+func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 	b := bazelNew()
 	b.SetArguments(c.bazelArgs)
 
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
 
-	c.cmd = start(b, c.target, c.args)
+	outputBuffer, foo := start(b, c.target, c.args)
+	c.cmd = foo
 	// Keep the writer around.
 	var err error
 	c.stdin, err = c.cmd.StdinPipe()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error getting stdin pipe: %v\n", err)
-		return err
+		return outputBuffer, err
 	}
 
 	c.cmd.Env = append(os.Environ(), "IBAZEL_NOTIFY_CHANGES=y")
 
 	if err = c.cmd.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error starting process: %v\n", err)
-		return err
+		return outputBuffer, err
 	}
 	fmt.Fprintf(os.Stderr, "Starting...")
-	return nil
+	return outputBuffer, nil
 }
 
-func (c *notifyCommand) NotifyOfChanges() {
+func (c *notifyCommand) NotifyOfChanges() *bytes.Buffer {
 	b := bazelNew()
 	b.SetArguments(c.bazelArgs)
 
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
 
-	res := b.Build(c.target)
+	outputBuffer, res := b.Build(c.target)
 	if res != nil {
 		fmt.Fprintf(os.Stderr, "FAILURE: %v\n", res)
 		_, err := c.stdin.Write([]byte("IBAZEL_BUILD_COMPLETED FAILURE\n"))
@@ -103,6 +105,7 @@ func (c *notifyCommand) NotifyOfChanges() {
 			fmt.Fprintf(os.Stderr, "Error writing success to stdin: %v\n", err)
 		}
 	}
+	return outputBuffer
 }
 
 func (c *notifyCommand) IsSubprocessRunning() bool {

--- a/ibazel/command/notify_command_test.go
+++ b/ibazel/command/notify_command_test.go
@@ -51,11 +51,11 @@ func TestNotifyCommand(t *testing.T) {
 	bazelNew = func() bazel.Bazel { return b }
 	defer func() { bazelNew = oldBazelNew }()
 
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	b.BuildError(errors.New("Demo error"))
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	b.BuildError(nil)
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 
 	b.AssertActions(t, [][]string{
 		[]string{"WriteToStderr"},

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"reflect"
@@ -26,6 +27,7 @@ import (
 	"github.com/bazelbuild/bazel-watcher/bazel"
 	mock_bazel "github.com/bazelbuild/bazel-watcher/bazel/testing"
 	"github.com/bazelbuild/bazel-watcher/ibazel/command"
+	"github.com/bazelbuild/bazel-watcher/ibazel/workspace_finder"
 	"github.com/fsnotify/fsnotify"
 
 	blaze_query "github.com/bazelbuild/bazel-watcher/third_party/bazel/master/src/main/protobuf"
@@ -51,15 +53,16 @@ type mockCommand struct {
 	terminated        bool
 }
 
-func (m *mockCommand) Start() error {
+func (m *mockCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 	if m.started {
 		panic("Can't run command twice")
 	}
 	m.started = true
-	return nil
+	return nil, nil
 }
-func (m *mockCommand) NotifyOfChanges() {
+func (m *mockCommand) NotifyOfChanges(logFile *os.File) *bytes.Buffer {
 	m.notifiedOfChanges = true
+	return nil
 }
 func (m *mockCommand) Terminate() {
 	if !m.started {
@@ -124,7 +127,7 @@ func newIBazel(t *testing.T) *IBazel {
 		t.Errorf("Error creating IBazel: %s", err)
 	}
 
-	i.workspaceFinder = &FakeWorkspaceFinder{}
+	i.workspaceFinder = &workspace_finder.FakeWorkspaceFinder{}
 
 	return i
 }
@@ -154,9 +157,9 @@ func TestIBazelLoop(t *testing.T) {
 
 	// First let's consume all the events from all the channels we care about
 	called := false
-	command := func(targets ...string) error {
+	command := func(targets ...string) (*bytes.Buffer, error) {
 		called = true
-		return nil
+		return nil, nil
 	}
 
 	i.state = QUERY
@@ -318,7 +321,7 @@ func TestHandleSignals_SIGINT(t *testing.T) {
 	// dead to test the job not responding)
 	for j := 0; j < 2; j++ {
 		cmd = &mockCommand{}
-		cmd.Start()
+		cmd.Start(nil)
 		i.cmd = cmd
 
 		// This should kill the subprocess and simulate hitting ctrl-c
@@ -355,7 +358,7 @@ func TestHandleSignals_SIGTERM(t *testing.T) {
 	attemptedExit = false
 
 	cmd := &mockCommand{}
-	cmd.Start()
+	cmd.Start(nil)
 	i.cmd = cmd
 
 	i.sigs <- syscall.SIGTERM

--- a/ibazel/lifecycle.go
+++ b/ibazel/lifecycle.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+
 	"github.com/bazelbuild/bazel-watcher/third_party/bazel/master/src/main/protobuf"
 )
 
@@ -29,5 +31,5 @@ type Lifecycle interface {
 	// AfterCommand is called after a blaze $COMMAND is run with the result of
 	// that command.
 	// command: "build"|"test"|"run"
-	AfterCommand(targets []string, command string, success bool)
+	AfterCommand(targets []string, command string, success bool, output *bytes.Buffer)
 }

--- a/ibazel/live_reload/server.go
+++ b/ibazel/live_reload/server.go
@@ -15,6 +15,7 @@
 package live_reload
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"log"
@@ -71,7 +72,7 @@ func (l *LiveReloadServer) ChangeDetected(targets []string, changeType string, c
 
 func (l *LiveReloadServer) BeforeCommand(targets []string, command string) {}
 
-func (l *LiveReloadServer) AfterCommand(targets []string, command string, success bool) {
+func (l *LiveReloadServer) AfterCommand(targets []string, command string, success bool, output *bytes.Buffer) {
 	l.triggerReload(targets)
 }
 

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -28,6 +28,7 @@ var Version = "Development"
 var overrideableBazelFlags []string = []string{
 	"--test_output=",
 	"--config=",
+	"--curses=no",
 }
 
 var debounceDuration = flag.Duration("debounce", 100*time.Millisecond, "Debounce duration")
@@ -114,7 +115,7 @@ func main() {
 
 	i, err := New()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating iBazel", err)
+		fmt.Fprintf(os.Stderr, "Error creating iBazel: %s\n", err)
 		os.Exit(1)
 	}
 	i.SetDebounceDuration(*debounceDuration)

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -65,7 +65,7 @@ func isOverrideableBazelFlag(arg string) bool {
 	return false
 }
 
-func parseArgs(in []string) (targets, bazelArgs, args []string) {
+func parseArgs(in []string) (targets, bazelArgs, args []string, debugArgs [][]string) {
 	afterDoubleDash := false
 	for _, arg := range in {
 		if afterDoubleDash {
@@ -85,7 +85,16 @@ func parseArgs(in []string) (targets, bazelArgs, args []string) {
 			}
 
 			// If none of those things then it's probably a target.
-			targets = append(targets, arg)
+			if strings.HasPrefix(arg, "--arg") {
+				parsedArg := strings.Replace(arg, "--arg=", "", -1)
+				if strings.Contains(parsedArg, " ") {
+					parsedArg = "\"" + parsedArg + "\""
+				}
+				debugArgs[len(debugArgs)-1] = append(debugArgs[len(debugArgs)-1], parsedArg)
+			} else {
+				targets = append(targets, arg)
+				debugArgs = append(debugArgs, []string{})
+			}
 		}
 	}
 	return
@@ -132,7 +141,7 @@ func main() {
 }
 
 func handle(i *IBazel, command string, args []string) {
-	targets, bazelArgs, args := parseArgs(args)
+	targets, bazelArgs, args, debugArgs := parseArgs(args)
 	i.SetBazelArgs(bazelArgs)
 
 	switch command {
@@ -142,7 +151,9 @@ func handle(i *IBazel, command string, args []string) {
 		i.Test(targets...)
 	case "run":
 		// Run only takes one argument
-		i.Run(targets[0], args)
+		i.Run(targets, args)
+	case "mrun":
+		i.RunMultiple(targets, args, debugArgs)
 	default:
 		fmt.Fprintf(os.Stderr, "Asked me to perform %s. I don't know how to do that.", command)
 		usage()

--- a/ibazel/output_runner/BUILD
+++ b/ibazel/output_runner/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017 The Bazel Authors. All rights reserved.
+# Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,49 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_binary")
-
-go_binary(
-    name = "ibazel",
-    embed = [":go_default_library"],
-    importpath = "github.com/bazelbuild/bazel-watcher/ibazel",
-    # Since we don't have any cgo dependencies, force build to be pure
-    # golang. This will make multi-os compatability *MUCH* easier.
-    pure = "on",
-    visibility = ["//visibility:public"],
-    x_defs = {
-        "main.Version": "{STABLE_GIT_VERSION}",
-    },
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = [
-        "ibazel.go",
-        "lifecycle.go",
-        "main.go",
-        "source_event_handler.go",
+        "output_runner.go",
     ],
-    importpath = "github.com/bazelbuild/bazel-watcher/ibazel",
-    visibility = ["//visibility:private"],
+    importpath = "github.com/bazelbuild/bazel-watcher/ibazel/output_runner",
+    visibility = ["//ibazel:__subpackages__"],
     deps = [
         "//bazel:go_default_library",
-        "//ibazel/command:go_default_library",
-        "//ibazel/output_runner:go_default_library",
-        "//ibazel/profiler:go_default_library",
-        "//ibazel/live_reload:go_default_library",
-        "//ibazel/workspace_finder:go_default_library",
         "//third_party/bazel/master/src/main/protobuf:go_default_library",
-        "@com_github_fsnotify_fsnotify//:go_default_library",
+        "//ibazel/workspace_finder:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
     srcs = [
-        "ibazel_test.go",
-        "main_test.go",
+        "output_runner_test.go",
     ],
+    data = ["output_runner_test.json"],
     embed = [":go_default_library"],
     importpath = "github.com/bazelbuild/bazel-watcher/ibazel",
     deps = [

--- a/ibazel/output_runner/output_runner.go
+++ b/ibazel/output_runner/output_runner.go
@@ -1,0 +1,173 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package output_runner
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"strconv"
+
+	"github.com/bazelbuild/bazel-watcher/ibazel/workspace_finder"
+	blaze_query "github.com/bazelbuild/bazel-watcher/third_party/bazel/master/src/main/protobuf"
+)
+
+var runOutput = flag.String("run_output", "", "Search for commands in Bazel output that match a regex and execute them, assign a JSON config file for regex")
+var runOutputInteractive = flag.Bool(
+	"run_output_interactive",
+	true,
+	"Use an interactive prompt when executing commands in Bazel output")
+
+type OutputRunner struct{}
+
+type Optcmd struct {
+	Regex string `json:"regex"`
+	Command string `json:"command"`
+	Args []string `json:"args"`
+}
+
+func New() *OutputRunner {
+	i := &OutputRunner{}
+	return i
+}
+
+func (i *OutputRunner) Initialize(info *map[string]string) {}
+
+func (i *OutputRunner) TargetDecider(rule *blaze_query.Rule) {}
+
+func (i *OutputRunner) ChangeDetected(targets []string, changeType string, change string) {}
+
+func (i *OutputRunner) BeforeCommand(targets []string, command string) {}
+
+func (i *OutputRunner) AfterCommand(targets []string, command string, success bool, output *bytes.Buffer) {
+	if *runOutput == "" || output == nil {
+		return
+	}
+	optcmd := readConfigs(*runOutput)
+	command_lines, commands, args := matchRegex(optcmd, output)
+	for idx, _ := range command_lines {
+		if *runOutputInteractive {
+			if promptCommand(command_lines[idx]) {
+				executeCommand(commands[idx], args[idx])
+			}
+		} else {
+			executeCommand(commands[idx], args[idx])
+		}
+	}
+}
+
+func readConfigs(configPath string) []Optcmd {
+	jsonFile, err := os.Open(configPath)
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer jsonFile.Close()
+
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+	var optcmd []Optcmd
+	json.Unmarshal(byteValue, &optcmd)
+
+	return optcmd
+}
+
+func matchRegex(optcmd []Optcmd, output *bytes.Buffer) ([]string, []string, [][]string) {
+	var command_lines, commands []string
+	var args [][]string
+	scanner := bufio.NewScanner(output)
+	for scanner.Scan() {
+		line := scanner.Text()
+		for _, oc := range optcmd {
+			re := regexp.MustCompile(oc.Regex)
+			matches := re.FindStringSubmatch(line)
+			if matches != nil && len(matches) >= 3 {
+				command_lines = append(command_lines, matches[0])
+				commands = append(commands, convertArg(matches, oc.Command))
+				args = append(args, convertArgs(matches, oc.Args))
+			}
+		}
+	}
+	return command_lines, commands, args
+}
+
+func convertArg(matches []string, arg string) string {
+	if strings.HasPrefix(arg, "$") {
+		val, _ := strconv.Atoi(arg[1:])
+		return matches[val]
+	}
+	return arg
+}
+
+func convertArgs(matches []string, args []string) []string {
+	var rst []string
+	for i, _ := range args {
+		if strings.HasPrefix(args[i], "$") {
+			val, _ := strconv.Atoi(args[i][1:])
+			rst = append(rst, matches[val])
+		} else {
+			rst = append(rst, args[i])
+		}
+	}
+	return rst
+}
+
+func promptCommand(command string) bool {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Fprintf(os.Stderr, "Do you want to execute this command?\n%s\n[y/N]", command)
+	text, _ := reader.ReadString('\n')
+	text = strings.ToLower(text)
+	text = strings.TrimSpace(text)
+	text = strings.TrimRight(text, "\n")
+	if text == "y" {
+		return true
+	} else {
+		return false
+	}
+}
+
+func executeCommand(command string, args []string) {
+	for i, arg := range args {
+		args[i] = strings.TrimSpace(arg)
+	}
+	fmt.Fprintf(os.Stderr, "Executing command: %s\n", command)
+	workspaceFinder := &workspace_finder.MainWorkspaceFinder{}
+	workspacePath, err := workspaceFinder.FindWorkspace()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error finding workspace: %v\n", err)
+		os.Exit(5)
+	}
+	fmt.Fprintf(os.Stderr, "Workspace path: %s\n", workspacePath)
+
+	ctx, _ := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, command, args...)
+	fmt.Fprintf(os.Stderr, "Executing command: %s %s\n", cmd.Path, strings.Join(cmd.Args, ","))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = workspacePath
+
+	err = cmd.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Command failed: %s %s. Error: %s\n", command, args, err)
+	}
+}
+
+func (i *OutputRunner) Cleanup() {}

--- a/ibazel/output_runner/output_runner_test.go
+++ b/ibazel/output_runner/output_runner_test.go
@@ -1,0 +1,117 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package output_runner
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestConvertArgs(t *testing.T) {
+	matches := []string{"my_command my_arg1 my_arg2 my_arg3", "my_command", "my_arg1", "my_arg2", "my_arg3"}
+	// Command parsing tests
+	for _, c := range []struct {
+		cmd   string
+		truth string
+	}{
+		{"$1", "my_command"},
+		{"warning", "warning"},
+		{"keep_command", "keep_command"},
+	} {
+		new_cmd := convertArg(matches, c.cmd)
+		if !reflect.DeepEqual(c.truth, new_cmd) {
+			t.Errorf("Command not equal: %v\nGot:  %v\nWant: %v",
+				c.cmd, new_cmd, c.truth)
+		}
+	}
+	// Arguments parsing tests
+	for _, c := range []struct {
+		cmd   []string
+		truth []string
+	}{
+		{[]string{"$2", "$3"}, []string{"my_arg1", "my_arg2"}},
+		{[]string{"$2", "$3", "$4"}, []string{"my_arg1", "my_arg2", "my_arg3"}},
+		{[]string{"$2", "dont_change_arg"}, []string{"my_arg1", "dont_change_arg"}},
+		{[]string{"keep_arg", "$3"}, []string{"keep_arg", "my_arg2"}},
+	} {
+		new_cmd := convertArgs(matches, c.cmd)
+		if !reflect.DeepEqual(c.truth, new_cmd) {
+			t.Errorf("Command not equal: %v\nGot:  %v\nWant: %v",
+				c.cmd, new_cmd, c.truth)
+		}
+	}
+}
+
+func TestReadConfigs(t *testing.T) {
+	optcmd := readConfigs("output_runner_test.json")
+
+	for idx, c := range []struct {
+		regex   string
+		command string
+		args    []string
+	}{
+		{"^(buildozer) '(.*)'\\s+(.*)$", "$1", []string{"$2", "$3"}},
+		{"WARNING", "warn", []string{"keep_calm", "dont_panic"}},
+		{"DANGER", "danger", []string{"be_careful", "why_so_serious"}},
+	} {
+		if !reflect.DeepEqual(c.regex, optcmd[idx].Regex) {
+			t.Errorf("Regex not equal: %v\nGot:  %v\nWant: %v",
+				optcmd[idx], optcmd[idx].Regex, c.regex)
+		}
+		if !reflect.DeepEqual(c.command, optcmd[idx].Command) {
+			t.Errorf("Command not equal: %v\nGot:  %v\nWant: %v",
+				optcmd[idx], optcmd[idx].Command, c.command)
+		}
+		if !reflect.DeepEqual(c.args, optcmd[idx].Args) {
+			t.Errorf("Args not equal: %v\nGot:  %v\nWant: %v",
+				optcmd[idx], optcmd[idx].Args, c.args)
+		}
+	}
+}
+
+func TestMatchRegex(t *testing.T) {
+	buf := bytes.Buffer{}
+	buf.WriteString("buildozer 'add deps test_dep1' //target1:target1\n")
+	buf.WriteString("buildozer 'add deps test_dep2' //target2:target2\n")
+	buf.WriteString("buildifier 'cmd_nvm' //target_nvm:target_nvm\n")
+	buf.WriteString("not_a_match 'nvm' //target_nvm:target_nvm\n")
+
+	optcmd := []Optcmd{
+		{Regex: "^(buildozer) '(.*)'\\s+(.*)$", Command: "$1", Args: []string{"$2", "$3"}},
+		{Regex: "^(buildifier) '(.*)'\\s+(.*)$", Command: "test_cmd", Args: []string{"test_arg1", "test_arg2"}},
+	}
+
+	_, commands, args := matchRegex(optcmd, &buf)
+
+	for idx, c := range []struct {
+		cls string
+		cs  string
+		as  []string
+	}{
+		{"buildozer 'add deps test_dep1' //target1:target1", "buildozer", []string{"add deps test_dep1", "//target1:target1"}},
+		{"buildozer 'add deps test_dep2' //target2:target2", "buildozer", []string{"add deps test_dep2", "//target2:target2"}},
+		{"buildifier 'cmd_nvm' //target_nvm:target_nvm", "test_cmd", []string{"test_arg1", "test_arg2"}},
+	} {
+		if !reflect.DeepEqual(c.cs, commands[idx]) {
+			t.Errorf("Commands not equal: %v\nGot:  %v\nWant: %v",
+				c.cls, commands[idx], c.cs)
+		}
+		if !reflect.DeepEqual(c.as, args[idx]) {
+			t.Errorf("Arguments not equal: %v\nGot:  %v\nWant: %v",
+				c.cls, args[idx], c.as)
+		}
+	}
+}

--- a/ibazel/output_runner/output_runner_test.json
+++ b/ibazel/output_runner/output_runner_test.json
@@ -1,0 +1,17 @@
+[
+	{
+		"regex": "^(buildozer) '(.*)'\\s+(.*)$",
+		"command": "$1",
+		"args": ["$2", "$3"]
+	},
+	{
+		"regex": "WARNING",
+		"command": "warn",
+		"args": ["keep_calm", "dont_panic"]
+	},
+	{
+		"regex": "DANGER",
+		"command": "danger",
+		"args": ["be_careful", "why_so_serious"]
+	}
+]

--- a/ibazel/profiler/profiler.go
+++ b/ibazel/profiler/profiler.go
@@ -15,6 +15,7 @@
 package profiler
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -142,7 +143,7 @@ func (i *Profiler) BeforeCommand(targets []string, command string) {
 	}
 }
 
-func (i *Profiler) AfterCommand(targets []string, command string, success bool) {
+func (i *Profiler) AfterCommand(targets []string, command string, success bool, output *bytes.Buffer) {
 	if i.file == nil {
 		return
 	}

--- a/ibazel/workspace_finder/BUILD
+++ b/ibazel/workspace_finder/BUILD
@@ -1,0 +1,28 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "workspace_finder.go",
+    ],
+    importpath = "github.com/bazelbuild/bazel-watcher/ibazel/workspace_finder",
+    visibility = ["//ibazel:__subpackages__"],
+    deps = [
+      "//third_party/bazel/master/src/main/protobuf:go_default_library",
+      "//bazel:go_default_library",
+    ],
+)

--- a/ibazel/workspace_finder/workspace_finder.go
+++ b/ibazel/workspace_finder/workspace_finder.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package workspace_finder
 
 import (
 	"errors"


### PR DESCRIPTION
# Output Runner
## Issue
When we build a target with Bazel, if we got redundant or missing deps, there is a prompt like
```
You can use the following buildozer command:
buildozer 'add deps @deps_name' //target:target
```
or
```
You can use the following buildozer command:
buildozer 'remove deps @deps_name' //target:target
```
The build fails and hangs.
## Fix
We monitor the Bazel logs for these kinds of information. We generate an interactive prompt 
```
Do you want to execute this command?
buildozer 'add deps @deps_name' //target:target
[y/N]
```
Users can reply `y` to fix the deps problem and rebuild.

The command matching is defined by regex and it is configurable by JSON. Users are able to decide what to monitor.

To enable output runner, use flag `-run_output=config_file_name.json`. The config file format is provided in `ibazel/output_runner/output_runner_test.json`.

# Multiple Runs
## Issue
iBazel currently only supports `run` for single target. Running multiple targets requires separate Bazel command executions and busy waiting for build processes.
## Fix
Implement a `mrun` command to run multiple targets with iBazel
```
ibazel mrun target1 --arg=t1_arg1 --arg=t1_arg2 target2 --arg=t2_arg1 --arg=t2_arg2
```
Append arbitrary number of targets after `mrun` with the corresponding arguments, prefixed with `--arg=`.
