### PR TITLE
Add test reproducing vim backupcopy=no and kqueue failure

### DIFF
--- a/e2e/simple/simple_test.go
+++ b/e2e/simple/simple_test.go
@@ -1,6 +1,8 @@
 package simple
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"runtime/debug"
 	"testing"
@@ -104,5 +106,111 @@ sh_binary(
 	srcs = ["test.sh"],
 )
 `))
+	ibazel.ExpectOutput("Started3!")
+}
+
+func renameAndWriteNewFile(t *testing.T, fname, content string) {
+	// write a file in the same manner as vim with backupcopy=no;
+	// this will rename the original file to a file with a backup extension
+	// and write the new file contents to the original filename
+
+	fnameBackup := fmt.Sprintf("%s~", fname)
+	must(t, os.Rename(fname, fnameBackup))
+	f, err := os.OpenFile(fname, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = f.Write([]byte(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	must(t, f.Close())
+	must(t, os.Remove(fnameBackup))
+}
+
+func copyAndTruncWriteFile(t *testing.T, fname string, content string) {
+	// write a file in the same manner as vim with backupcopy=yes;
+	// this will copy the file to a suffixed backup file,
+	// truncate the existing file and write the new content
+	fnameBackup := fmt.Sprintf("%s~", fname)
+
+	f, err := os.Open(fname)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fBackup, err := os.OpenFile(fnameBackup, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = io.Copy(fBackup, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	must(t, fBackup.Close())
+	must(t, f.Close())
+
+	f, err = os.OpenFile(fname, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = f.Write([]byte(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	must(t, f.Sync())
+	must(t, f.Close())
+	must(t, os.Remove(fnameBackup))
+}
+
+func TestSimpleRunWithModifiedFile_RenameAndWrite(t *testing.T) {
+	b, err := bazel.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	must(t, b.ScratchFile("WORKSPACE", ""))
+	must(t, b.ScratchFileWithMode("test.sh", `printf "Started!"`, 0777))
+	must(t, b.ScratchFile("BUILD", `
+sh_binary(
+	name = "test",
+	srcs = ["test.sh"],
+)
+`))
+
+	ibazel := e2e.NewIBazelTester(t, b)
+	ibazel.Run("//:test")
+	defer ibazel.Kill()
+	ibazel.ExpectOutput("Started!")
+
+	renameAndWriteNewFile(t, "test.sh", `printf "Started2!"`)
+	ibazel.ExpectOutput("Started2!")
+
+	renameAndWriteNewFile(t, "test.sh", `printf "Started3!"`)
+	ibazel.ExpectOutput("Started3!")
+}
+
+func TestSimpleRunWithModifiedFile_CopyAndTruncWrite(t *testing.T) {
+	b, err := bazel.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	must(t, b.ScratchFile("WORKSPACE", ""))
+	must(t, b.ScratchFileWithMode("test.sh", `printf "Started!"`, 0777))
+	must(t, b.ScratchFile("BUILD", `
+sh_binary(
+	name = "test",
+	srcs = ["test.sh"],
+)
+`))
+
+	ibazel := e2e.NewIBazelTester(t, b)
+	ibazel.Run("//:test")
+	defer ibazel.Kill()
+	ibazel.ExpectOutput("Started!")
+
+	copyAndTruncWriteFile(t, "test.sh", `printf "Started2!"`)
+	ibazel.ExpectOutput("Started2!")
+
+	copyAndTruncWriteFile(t, "test.sh", `printf "Started3!"`)
 	ibazel.ExpectOutput("Started3!")
 }

--- a/ibazel/source_event_handler.go
+++ b/ibazel/source_event_handler.go
@@ -14,7 +14,9 @@
 
 package main
 
-import "github.com/fsnotify/fsnotify"
+import (
+  "github.com/fsnotify/fsnotify"
+)
 
 type SourceEventHandler struct {
 	SourceFileEvents  chan fsnotify.Event
@@ -28,8 +30,8 @@ func (s *SourceEventHandler) Listen() {
 			s.SourceFileEvents <- event
 
 			switch event.Op {
-			case fsnotify.Remove:
-				s.SourceFileWatcher.Add(event.Name)
+			case fsnotify.Remove, fsnotify.Rename:
+					s.SourceFileWatcher.Add(event.Name)
 			}
 		}
 	}


### PR DESCRIPTION
This test reproduces the write behavior of vim with `backupcopy` set to both `yes` and `no`. `yes` is the default on Linux, and #10 fixed this case. Unforunately, on macOS, `yes` is not the default, and using `no` will cause ibazel to stop watching the file after a single file save when a kqueue-based file watcher is used. This is described in further detail in #117.

The fix for this might actually be the approach first used in #10 except for the `Rename` event, not just `Remove` (that is, waiting for vim to finish writing to the new file and re-adding the watcher on the original filename).

Otherwise, we may need to switch to an FSEvents-based implementation on macOS, which would require some upstream work on https://github.com/fsnotify/fsevents or waiting for https://github.com/fsnotify/fsnotify/issues/11 to be finished.