### PR TITLE
Add an extra sanity check to improve error message

### DIFF
--- a/e2e/live_reload/live_reload_test.go
+++ b/e2e/live_reload/live_reload_test.go
@@ -79,6 +79,10 @@ sh_binary(
 	ibazel.ExpectOutput("Live reload url: http://.+:\\d+")
 	out := ibazel.GetOutput()
 	t.Logf("Output: '%s'", out)
+	
+	if out == "" {
+		t.Fatal("Output was empty. Expected at least some output")
+	}
 
 	jsUrl := out[len("Live reload url: "):]
 	t.Logf("Livereload URL: '%s'", jsUrl)


### PR DESCRIPTION
When this test fails because output is empty it can be difficult
to parse the error output. Make the test much more explicit.