### PR TITLE
Increase e2e timeout

### DIFF
--- a/e2e/ibazel.go
+++ b/e2e/ibazel.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Maximum amount of time to wait before failing a test for not matching your expectations.
-var delay = 10 * time.Second
+var delay = 20 * time.Second
 
 type IBazelTester struct {
 	bazel *bazel.TestingBazel


### PR DESCRIPTION
Although an e2e timeout of 10 seconds seems to be sufficient for our Buildkite and Travis builds, I needed to increase it to 20 seconds for the e2e tests to pass reliably on my system.