### PR TITLE
Fix the output runner

### DIFF
--- a/bazel/bazel.go
+++ b/bazel/bazel.go
@@ -214,10 +214,10 @@ func (b *bazel) Run(args ...string) (*exec.Cmd, *bytes.Buffer, error) {
 
 	err := b.cmd.Run()
 	if err != nil {
-		return nil, stdoutBuffer, err
+		return nil, stderrBuffer, err
 	}
 
-	return b.cmd, stdoutBuffer, err
+	return b.cmd, stderrBuffer, err
 }
 
 func (b *bazel) Wait() error {


### PR DESCRIPTION
The problem is introduced by 'Uncross stdout and stderr buffers' https://github.com/bazelbuild/bazel-watcher/commit/add8041bfb843d5566e18b6711d88e4e10c5b699. Since we switched stdoutBuffer and stderrBuffer, `output_runner` is not reading the correct output log.