### PR TITLE
Added newline to 'Starting...' text

### DIFF
--- a/ibazel/command/default_command.go
+++ b/ibazel/command/default_command.go
@@ -73,7 +73,7 @@ func (c *defaultCommand) Start() (*bytes.Buffer, error) {
 		fmt.Fprintf(os.Stderr, "Error starting process: %v\n", err)
 		return outputBuffer, err
 	}
-	fmt.Fprintf(os.Stderr, "Starting...")
+	fmt.Fprintf(os.Stderr, "Starting...\n")
 	return outputBuffer, nil
 }
 

--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -81,7 +81,7 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 		fmt.Fprintf(os.Stderr, "Error starting process: %v\n", err)
 		return outputBuffer, err
 	}
-	fmt.Fprintf(os.Stderr, "Starting...")
+	fmt.Fprintf(os.Stderr, "Starting...\n")
 	return outputBuffer, nil
 }
 


### PR DESCRIPTION
I added a newline after the 'Starting...' text so that applications that depend on the output to start at position 0 are properly displayed while using `ibazel run`

**Before**
![image](https://user-images.githubusercontent.com/1284289/54094383-bb01fd00-435d-11e9-9bc9-e80b6669ad00.png)

**After**
![image](https://user-images.githubusercontent.com/1284289/54094369-9017a900-435d-11e9-83c1-848dcda57f35.png)