### PR TITLE
Enable e2e tests on Windows

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-git_repository(
+http_archive(
     name = "com_github_bazelbuild_bazel_integration_testing",
-    commit = "c0a04233201e5b26180c94e4be61c460bf0328e5",
-    remote = "https://github.com/bazelbuild/bazel-integration-testing",
+    sha256 = "d801cff1c9c4e2f0a32b68272d947a7264b36e67ed703f2a08c5efaea0a931ab",
+    strip_prefix = "bazel-integration-testing-19d678ab0798ce1ed5369c62fd494e6e2e3b8112",
+    url = "https://github.com/bazelbuild/bazel-integration-testing/archive/19d678ab0798ce1ed5369c62fd494e6e2e3b8112.tar.gz",  # 2018-12-10
 )
 
 load("@com_github_bazelbuild_bazel_integration_testing//tools:repositories.bzl", "bazel_binaries")

--- a/e2e/live_reload/BUILD
+++ b/e2e/live_reload/BUILD
@@ -10,7 +10,6 @@ bazel_go_integration_test(
         "//ibazel",
     ],
     importpath = "github.com/bazelbuild/bazel-watcher/e2e/live_reload",
-    tags = ["nowindows"],
     versions = GET_LATEST_BAZEL_VERSIONS(),
     deps = [
         "//e2e:go_default_library",

--- a/e2e/output_runner/BUILD
+++ b/e2e/output_runner/BUILD
@@ -8,7 +8,6 @@ bazel_go_integration_test(
         "//ibazel",
     ],
     importpath = "github.com/bazelbuild/bazel-watcher/e2e/output_runner",
-    tags = ["nowindows"],
     versions = GET_LATEST_BAZEL_VERSIONS(),
     deps = [
         "//e2e:go_default_library",

--- a/e2e/output_runner/output_runner_test.go
+++ b/e2e/output_runner/output_runner_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime/debug"
+	"strings"
 	"testing"
 
 	bazel "github.com/bazelbuild/bazel-integration-testing/go"
@@ -51,7 +52,7 @@ func TestOutputRunner(t *testing.T) {
 	"command": "touch",
 	"args": ["%s"]
 }]
-`, sentinelFile.Name())))
+`, strings.Replace(sentinelFile.Name(), "\\", "/", -1))))
 	must(t, b.ScratchFile("WORKSPACE", ""))
 	must(t, b.ScratchFileWithMode("test.sh", `printf "action"`, 0777))
 	must(t, b.ScratchFile("defs.bzl", `

--- a/e2e/profiler/BUILD
+++ b/e2e/profiler/BUILD
@@ -10,7 +10,6 @@ bazel_go_integration_test(
         "//ibazel",
     ],
     importpath = "github.com/bazelbuild/bazel-watcher/e2e/profiler",
-    tags = ["nowindows"],
     versions = GET_LATEST_BAZEL_VERSIONS(),
     deps = [
         "//e2e:go_default_library",

--- a/e2e/simple/BUILD
+++ b/e2e/simple/BUILD
@@ -10,7 +10,6 @@ bazel_go_integration_test(
         "//ibazel",
     ],
     importpath = "github.com/bazelbuild/bazel-watcher/e2e/simple",
-    tags = ["nowindows"],
     versions = GET_LATEST_BAZEL_VERSIONS(),
     deps = [
         "//e2e:go_default_library",


### PR DESCRIPTION
After https://github.com/bazelbuild/bazel-integration-testing/pull/117 is merged, we can change the commit of `com_github_bazelbuild_bazel_integration_testing` to the correct one. Then we can run e2e tests on Windows finally!