### PR TITLE
Fix windows binary resolution on node

### DIFF
--- a/release/npm/index.js
+++ b/release/npm/index.js
@@ -29,12 +29,12 @@ function getNativeBinary() {
   const platform = {
     'darwin' : 'darwin',
     'linux' : 'linux',
-    'windows' : 'windows',
+    'win32' : 'windows',
   }[os.platform()];
   const extension = {
     'darwin' : '',
     'linux' : '',
-    'windows' : '.exe',
+    'win32' : '.exe',
   }[os.platform()];
 
   if (arch == undefined || platform == undefined) {


### PR DESCRIPTION
Relevant issue:

https://github.com/bazelbuild/bazel-watcher/issues/105#issuecomment-487960158