### PR TITLE
Pass bazel args for run command.

### DIFF
--- a/bazel/bazel.go
+++ b/bazel/bazel.go
@@ -207,7 +207,7 @@ func (b *bazel) Test(args ...string) (*bytes.Buffer, error) {
 func (b *bazel) Run(args ...string) (*exec.Cmd, *bytes.Buffer, error) {
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
-	stdoutBuffer, stderrBuffer := b.newCommand("run", args...)
+	stdoutBuffer, stderrBuffer := b.newCommand("run", append(b.args, args...)...)
 	b.cmd.Stdin = os.Stdin
 
 	_, _ = stdoutBuffer.Write(stderrBuffer.Bytes())

--- a/e2e/ibazel.go
+++ b/e2e/ibazel.go
@@ -44,18 +44,18 @@ func (i *IBazelTester) Build(target string) {
 }
 
 func (i *IBazelTester) Run(target string, bazelArgs ...string) {
-	i.run(target, []string{}, bazelArgs)
+	i.run(target, bazelArgs, []string{})
 }
 
 func (i *IBazelTester) RunWithProfiler(target string, profiler string) {
-	i.run(target, []string{"--profile_dev=" + profiler}, []string{})
+	i.run(target, []string{}, []string{"--profile_dev=" + profiler})
 }
 
 func (i *IBazelTester) RunWithBazelFixCommands(target string) {
-	i.run(target, []string{
+	i.run(target, []string{}, []string{
 		"--run_output=true",
 		"--run_output_interactive=false",
-	}, []string{})
+	})
 }
 
 func (i *IBazelTester) GetOutput() string {
@@ -157,7 +157,7 @@ func (i *IBazelTester) build(target string, additionalArgs []string) {
 	}
 }
 
-func (i *IBazelTester) run(target string, additionalArgs []string, bazelArgs []string) {
+func (i *IBazelTester) run(target string, bazelArgs []string, additionalArgs []string) {
 	args := []string{"--bazel_path=" + i.bazelPath()}
 	args = append(args, additionalArgs...)
 	args = append(args, "run")

--- a/e2e/ibazel.go
+++ b/e2e/ibazel.go
@@ -43,19 +43,19 @@ func (i *IBazelTester) Build(target string) {
 	i.build(target, []string{})
 }
 
-func (i *IBazelTester) Run(target string) {
-	i.run(target, []string{})
+func (i *IBazelTester) Run(target string, bazelArgs ...string) {
+	i.run(target, []string{}, bazelArgs)
 }
 
 func (i *IBazelTester) RunWithProfiler(target string, profiler string) {
-	i.run(target, []string{"--profile_dev=" + profiler})
+	i.run(target, []string{"--profile_dev=" + profiler}, []string{})
 }
 
 func (i *IBazelTester) RunWithBazelFixCommands(target string) {
 	i.run(target, []string{
 		"--run_output=true",
 		"--run_output_interactive=false",
-	})
+	}, []string{})
 }
 
 func (i *IBazelTester) GetOutput() string {
@@ -157,11 +157,12 @@ func (i *IBazelTester) build(target string, additionalArgs []string) {
 	}
 }
 
-func (i *IBazelTester) run(target string, additionalArgs []string) {
+func (i *IBazelTester) run(target string, additionalArgs []string, bazelArgs []string) {
 	args := []string{"--bazel_path=" + i.bazelPath()}
 	args = append(args, additionalArgs...)
 	args = append(args, "run")
 	args = append(args, target)
+	args = append(args, bazelArgs...)
 	i.cmd = exec.Command(ibazelPath, args...)
 
 	errCode, buildStdout, buildStderr := i.bazel.RunBazel([]string{"build", target})

--- a/e2e/ibazel.go
+++ b/e2e/ibazel.go
@@ -43,7 +43,7 @@ func (i *IBazelTester) Build(target string) {
 	i.build(target, []string{})
 }
 
-func (i *IBazelTester) Run(target string, bazelArgs ...string) {
+func (i *IBazelTester) Run(bazelArgs []string, target string) {
 	i.run(target, bazelArgs, []string{})
 }
 

--- a/e2e/live_reload/live_reload_test.go
+++ b/e2e/live_reload/live_reload_test.go
@@ -73,7 +73,7 @@ sh_binary(
 `))
 
 	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run("//:live_reload")
+	ibazel.Run([]string{}, "//:live_reload")
 	defer ibazel.Kill()
 
 	ibazel.ExpectOutput("Live reload url: http://.+:\\d+")
@@ -163,7 +163,7 @@ sh_binary(
 `))
 
 	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run("//:no_live_reload")
+	ibazel.Run([]string{}, "//:no_live_reload")
 	defer ibazel.Kill()
 
 	// Expect there to not be a url since this is the negative test case.

--- a/e2e/profiler/profiler_test.go
+++ b/e2e/profiler/profiler_test.go
@@ -142,7 +142,7 @@ sh_binary(
 `))
 
 	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run("//:no_profiler")
+	ibazel.Run([]string{}, "//:no_profiler")
 	defer ibazel.Kill()
 
 	ibazel.ExpectOutput("Profiler url: $")

--- a/e2e/simple/simple_test.go
+++ b/e2e/simple/simple_test.go
@@ -189,6 +189,36 @@ sh_binary(
 	ibazel.ExpectOutput("Started3!")
 }
 
+func TestSimpleRunWithFlag(t *testing.T) {
+	b, err := bazel.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	must(t, b.ScratchFile("WORKSPACE", ""))
+	must(t, b.ScratchFileWithMode("test_1.sh", `printf "Started 1!"`, 0777))
+	must(t, b.ScratchFileWithMode("test_2.sh", `printf "Started 2!"`, 0777))
+	must(t, b.ScratchFile("BUILD", `
+config_setting(
+	name = "test_is_2",
+	values = {"define": "test_number=2"},
+)
+
+sh_binary(
+	name = "test",
+	srcs = select({
+        ":test_is_2": ["test_2.sh"],
+        "//conditions:default": ["test_1.sh"],
+    }),
+)
+`))
+
+	ibazel := e2e.NewIBazelTester(t, b)
+	ibazel.Run("//:test", "--define=test_number=2")
+	defer ibazel.Kill()
+
+	ibazel.ExpectOutput("Started 2!")
+}
+
 func renameAndWriteNewFile(t *testing.T, fname, content string) {
 	// write a file in the same manner as vim with backupcopy=no;
 	// this will rename the original file to a file with a backup extension

--- a/e2e/simple/simple_test.go
+++ b/e2e/simple/simple_test.go
@@ -87,7 +87,7 @@ sh_binary(
 `))
 
 	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run("//:test")
+	ibazel.Run([]string{}, "//:test")
 	defer ibazel.Kill()
 
 	ibazel.ExpectOutput("Started!")
@@ -113,7 +113,7 @@ sh_binary(
 	}
 
 	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run("//:test")
+	ibazel.Run([]string{}, "//:test")
 	defer ibazel.Kill()
 
 	ibazel.ExpectOutput("Started!")
@@ -141,7 +141,7 @@ sh_binary(
 		t.Fatal(err)
 	}
 
-	ibazel.Run("test")
+	ibazel.Run([]string{}, "test")
 	defer ibazel.Kill()
 
 	err = os.Chdir("..")
@@ -167,7 +167,7 @@ sh_binary(
 `))
 
 	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run("//:test")
+	ibazel.Run([]string{}, "//:test")
 	defer ibazel.Kill()
 
 	// Give it time to start up and query.
@@ -213,7 +213,7 @@ sh_binary(
 `))
 
 	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run("//:test", "--define=test_number=2")
+	ibazel.Run([]string{"--define=test_number=2"}, "//:test")
 	defer ibazel.Kill()
 
 	ibazel.ExpectOutput("Started 2!")
@@ -288,7 +288,7 @@ sh_binary(
 `))
 
 	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run("//:test")
+	ibazel.Run([]string{}, "//:test")
 	defer ibazel.Kill()
 	ibazel.ExpectOutput("Started!")
 
@@ -314,7 +314,7 @@ sh_binary(
 `))
 
 	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run("//:test")
+	ibazel.Run([]string{}, "//:test")
 	defer ibazel.Kill()
 	ibazel.ExpectOutput("Started!")
 


### PR DESCRIPTION
Fixes #269

----
also:
 - extends `IBazelTester` so that Bazel flags can be passed
 - adds an e2e test covering the case