### PR TITLE
Add support for startup option bazelrc

### DIFF
--- a/bazel/bazel.go
+++ b/bazel/bazel.go
@@ -102,10 +102,13 @@ type Bazel interface {
 
 type bazel struct {
 	cmd           *exec.Cmd
+
 	args          []string
+	startupArgs   []string
+
 	ctx           context.Context
 	cancel        context.CancelFunc
-	startupArgs   []string
+
 	writeToStderr bool
 	writeToStdout bool
 }

--- a/bazel/bazel.go
+++ b/bazel/bazel.go
@@ -88,6 +88,7 @@ func findBazel() (string) {
 
 type Bazel interface {
 	SetArguments([]string)
+	SetStartupArgs([]string)
 	WriteToStderr(v bool)
 	WriteToStdout(v bool)
 	Info() (map[string]string, error)
@@ -104,6 +105,7 @@ type bazel struct {
 	args          []string
 	ctx           context.Context
 	cancel        context.CancelFunc
+	startupArgs   []string
 	writeToStderr bool
 	writeToStdout bool
 }
@@ -114,6 +116,10 @@ func New() Bazel {
 
 func (b *bazel) SetArguments(args []string) {
 	b.args = args
+}
+
+func (b *bazel) SetStartupArgs(args []string) {
+	b.startupArgs = args
 }
 
 // WriteToStderr when running an operation.
@@ -130,6 +136,7 @@ func (b *bazel) newCommand(command string, args ...string) (*bytes.Buffer, *byte
 	b.ctx, b.cancel = context.WithCancel(context.Background())
 
 	args = append([]string{command}, args...)
+	args = append(b.startupArgs, args...)
 
 	if b.writeToStderr || b.writeToStdout {
 		containsColor := false

--- a/bazel/testing/mock.go
+++ b/bazel/testing/mock.go
@@ -27,6 +27,7 @@ type MockBazel struct {
 	actions       [][]string
 	queryResponse map[string]*blaze_query.QueryResult
 	args          []string
+	startupArgs   []string
 
 	buildError error
 	waitError  error
@@ -34,6 +35,10 @@ type MockBazel struct {
 
 func (b *MockBazel) SetArguments(args []string) {
 	b.args = args
+}
+
+func (b *MockBazel) SetStartupArgs(args []string) {
+	b.startupArgs = args
 }
 
 func (b *MockBazel) WriteToStderr(v bool) {

--- a/ibazel/command/default_command.go
+++ b/ibazel/command/default_command.go
@@ -23,20 +23,22 @@ import (
 )
 
 type defaultCommand struct {
-	target    string
-	bazelArgs []string
-	args      []string
-	pg        process_group.ProcessGroup
+	target       string
+	startupArgs	 []string
+	bazelArgs    []string
+	args         []string
+	pg           process_group.ProcessGroup
 }
 
 // DefaultCommand is the normal mode of interacting with iBazel. If you start a
 // server in this mode and notify of changes the server will be killed and
 // restarted.
-func DefaultCommand(bazelArgs []string, target string, args []string) Command {
+func DefaultCommand(startupArgs []string, bazelArgs []string, target string, args []string) Command {
 	return &defaultCommand{
-		target:    target,
-		bazelArgs: bazelArgs,
-		args:      args,
+		target:      target,
+		startupArgs: startupArgs,
+		bazelArgs:   bazelArgs,
+		args:        args,
 	}
 }
 
@@ -58,6 +60,7 @@ func (c *defaultCommand) Terminate() {
 
 func (c *defaultCommand) Start() (*bytes.Buffer, error) {
 	b := bazelNew()
+	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)
 
 	b.WriteToStderr(true)

--- a/ibazel/command/default_command.go
+++ b/ibazel/command/default_command.go
@@ -23,11 +23,11 @@ import (
 )
 
 type defaultCommand struct {
-	target       string
-	startupArgs	 []string
-	bazelArgs    []string
-	args         []string
-	pg           process_group.ProcessGroup
+	target      string
+	startupArgs []string
+	bazelArgs   []string
+	args        []string
+	pg          process_group.ProcessGroup
 }
 
 // DefaultCommand is the normal mode of interacting with iBazel. If you start a

--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -24,10 +24,10 @@ import (
 )
 
 type notifyCommand struct {
-	target       string
-	startupArgs  []string
-	bazelArgs    []string
-	args         []string
+	target      string
+	startupArgs []string
+	bazelArgs   []string
+	args        []string
 
 	pg    process_group.ProcessGroup
 	stdin io.WriteCloser
@@ -37,10 +37,10 @@ type notifyCommand struct {
 // command will be notified on stdin that the source files have changed.
 func NotifyCommand(startupArgs []string, bazelArgs []string, target string, args []string) Command {
 	return &notifyCommand{
-		startupArgs:    startupArgs,
-		target:    	    target,
-		bazelArgs:      bazelArgs,
-		args:           args,
+		startupArgs: startupArgs,
+		target:      target,
+		bazelArgs:   bazelArgs,
+		args:        args,
 	}
 }
 

--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -24,9 +24,10 @@ import (
 )
 
 type notifyCommand struct {
-	target    string
-	bazelArgs []string
-	args      []string
+	target       string
+	startupArgs  []string
+	bazelArgs    []string
+	args         []string
 
 	pg    process_group.ProcessGroup
 	stdin io.WriteCloser
@@ -34,11 +35,12 @@ type notifyCommand struct {
 
 // NotifyCommand is an alternate mode for starting a command. In this mode the
 // command will be notified on stdin that the source files have changed.
-func NotifyCommand(bazelArgs []string, target string, args []string) Command {
+func NotifyCommand(startupArgs []string, bazelArgs []string, target string, args []string) Command {
 	return &notifyCommand{
-		target:    target,
-		bazelArgs: bazelArgs,
-		args:      args,
+		startupArgs:    startupArgs,
+		target:    	    target,
+		bazelArgs:      bazelArgs,
+		args:           args,
 	}
 }
 
@@ -60,7 +62,9 @@ func (c *notifyCommand) Terminate() {
 
 func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 	b := bazelNew()
+	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)
+
 
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
@@ -87,6 +91,7 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 
 func (c *notifyCommand) NotifyOfChanges() *bytes.Buffer {
 	b := bazelNew()
+	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)
 
 	b.WriteToStderr(true)

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -59,9 +59,10 @@ const buildQuery = "buildfiles(deps(set(%s)))"
 type IBazel struct {
 	debounceDuration time.Duration
 
-	cmd       command.Command
-	args      []string
-	bazelArgs []string
+	cmd         command.Command
+	args        []string
+	bazelArgs   []string
+	startupArgs []string
 
 	sigs           chan os.Signal // Signals channel for the current process
 	interruptCount int
@@ -159,12 +160,17 @@ func (i *IBazel) handleSignals() {
 
 func (i *IBazel) newBazel() bazel.Bazel {
 	b := bazelNew()
+	b.SetStartupArgs(i.startupArgs)
 	b.SetArguments(i.bazelArgs)
 	return b
 }
 
 func (i *IBazel) SetBazelArgs(args []string) {
 	i.bazelArgs = args
+}
+
+func (i *IBazel) SetStartupArgs(args []string) {
+	i.startupArgs = args
 }
 
 func (i *IBazel) SetDebounceDuration(debounceDuration time.Duration) {
@@ -374,9 +380,9 @@ func (i *IBazel) setupRun(target string) command.Command {
 
 	if commandNotify {
 		fmt.Fprintf(os.Stderr, "Launching with notifications\n")
-		return commandNotifyCommand(i.bazelArgs, target, i.args)
+		return commandNotifyCommand(i.startupArgs, i.bazelArgs, target, i.args)
 	} else {
-		return commandDefaultCommand(i.bazelArgs, target, i.args)
+		return commandDefaultCommand(i.startupArgs, i.bazelArgs, target, i.args)
 	}
 }
 

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -58,6 +58,7 @@ func assertEqual(t *testing.T, want, got interface{}, msg string) {
 }
 
 type mockCommand struct {
+	startupArgs []string
 	bazelArgs []string
 	target    string
 	args      []string
@@ -125,9 +126,10 @@ func init() {
 		})
 		return mockBazel
 	}
-	commandDefaultCommand = func(bazelArgs []string, target string, args []string) command.Command {
+	commandDefaultCommand = func(startupArgs []string, bazelArgs []string, target string, args []string) command.Command {
 		// Don't do anything
 		return &mockCommand{
+			startupArgs: startupArgs,
 			bazelArgs: bazelArgs,
 			target:    target,
 			args:      args,
@@ -269,7 +271,8 @@ func TestIBazelRun_firstPass(t *testing.T) {
 }
 
 func TestIBazelRun_notifyPreexistiingJobWhenStarting(t *testing.T) {
-	commandDefaultCommand = func(bazelArgs []string, target string, args []string) command.Command {
+	commandDefaultCommand = func(startupArgs []string, bazelArgs []string, target string, args []string) command.Command {
+		assertEqual(t, startupArgs, []string{}, "Startup args")
 		assertEqual(t, bazelArgs, []string{}, "Bazel args")
 		assertEqual(t, target, "", "Target")
 		assertEqual(t, args, []string{}, "Args")

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -59,9 +59,9 @@ func assertEqual(t *testing.T, want, got interface{}, msg string) {
 
 type mockCommand struct {
 	startupArgs []string
-	bazelArgs []string
-	target    string
-	args      []string
+	bazelArgs   []string
+	target      string
+	args        []string
 
 	notifiedOfChanges bool
 	started           bool

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -24,10 +24,13 @@ import (
 
 var Version = "Development"
 
+var overrideableStartupFlags []string = []string{
+	"--bazelrc",
+}
+
 var overrideableBazelFlags []string = []string{
 	"--action_env",
 	"--announce_rc",
-	"--bazelrc",
 	"--config=",
 	"--curses=no",
 	"--define",
@@ -59,7 +62,7 @@ target, run, build, or test the specified targets.
 
 Usage:
 
-ibazel [flags] build|test|run targets...
+ibazel build|test|run [flags] targets...
 
 Example:
 
@@ -68,24 +71,35 @@ ibazel test //path/to/my/testing/targets/...
 ibazel run //path/to/my/runnable:target -- --arguments --for_your=binary
 ibazel build //path/to/my/buildable:target
 
-Supported Bazel flags:
+Supported Bazel startup flags:
+  %s
+
+Supported Bazel command flags:
   %s
 
 To add to this list, edit
 https://github.com/bazelbuild/bazel-watcher/blob/master/ibazel/main.go
 
 iBazel flags:
-`, Version, strings.Join(overrideableBazelFlags, "\n  "))
+`, Version, strings.Join(overrideableStartupFlags, "\n  "), strings.Join(overrideableBazelFlags, "\n  "))
 	flag.PrintDefaults()
 }
 
-func isOverrideableBazelFlag(arg string) bool {
-	for _, overrideable := range overrideableBazelFlags {
+func isOverrideable(arg string, overrideables []string) bool {
+	for _, overrideable := range overrideables {
 		if strings.HasPrefix(arg, overrideable) {
 			return true
 		}
 	}
 	return false
+}
+
+func isOverrideableStartupFlag(arg string) bool {
+	return isOverrideable(arg, overrideableStartupFlags)
+}
+
+func isOverrideableBazelFlag(arg string) bool {
+	return isOverrideable(arg, overrideableBazelFlags)
 }
 
 func parseArgs(in []string) (targets, startupArgs, bazelArgs, args []string) {
@@ -101,19 +115,15 @@ func parseArgs(in []string) (targets, startupArgs, bazelArgs, args []string) {
 				continue
 			}
 
-			// Check to see if this flag is on the bazel whitelist of flags.
-			if isOverrideableBazelFlag(arg) {
-				// TODO
-				if strings.HasPrefix(arg, "--bazelrc") {
-					startupArgs = append(startupArgs, arg)
-				} else {
-					bazelArgs = append(bazelArgs, arg)
-				}
-				continue
+			// Check to see if this startup option or command flag is on the bazel whitelist of flags.
+			if isOverrideableStartupFlag(arg) {
+				startupArgs = append(startupArgs, arg)
+			} else if isOverrideableBazelFlag(arg) {
+				bazelArgs = append(bazelArgs, arg)
+			} else {
+				// If none of those things then it's probably a target.
+				targets = append(targets, arg)
 			}
-
-			// If none of those things then it's probably a target.
-			targets = append(targets, arg)
 		}
 	}
 	return

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -26,6 +26,8 @@ var Version = "Development"
 
 var overrideableBazelFlags []string = []string{
 	"--action_env",
+	"--announce_rc",
+	"--bazelrc",
 	"--config=",
 	"--curses=no",
 	"--define",
@@ -86,7 +88,7 @@ func isOverrideableBazelFlag(arg string) bool {
 	return false
 }
 
-func parseArgs(in []string) (targets, bazelArgs, args []string) {
+func parseArgs(in []string) (targets, startupArgs, bazelArgs, args []string) {
 	afterDoubleDash := false
 	for _, arg := range in {
 		if afterDoubleDash {
@@ -101,7 +103,12 @@ func parseArgs(in []string) (targets, bazelArgs, args []string) {
 
 			// Check to see if this flag is on the bazel whitelist of flags.
 			if isOverrideableBazelFlag(arg) {
-				bazelArgs = append(bazelArgs, arg)
+				// TODO
+				if strings.HasPrefix(arg, "--bazelrc") {
+					startupArgs = append(startupArgs, arg)
+				} else {
+					bazelArgs = append(bazelArgs, arg)
+				}
 				continue
 			}
 
@@ -153,7 +160,8 @@ func main() {
 }
 
 func handle(i *IBazel, command string, args []string) {
-	targets, bazelArgs, args := parseArgs(args)
+	targets, startupArgs, bazelArgs, args := parseArgs(args)
+	i.SetStartupArgs(startupArgs)
 	i.SetBazelArgs(bazelArgs)
 
 	switch command {

--- a/ibazel/main_test.go
+++ b/ibazel/main_test.go
@@ -21,25 +21,32 @@ import (
 
 func TestParsingArgs(t *testing.T) {
 	for _, c := range []struct {
-		in        []string
-		targets   []string
-		bazelArgs []string
-		args      []string
+		in          []string
+		targets     []string
+		startupArgs []string
+		bazelArgs   []string
+		args        []string
 	}{
 		// Empty case.
-		{[]string{}, nil, nil, nil},
+		{[]string{}, nil, nil, nil, nil},
 		// Only targets.
-		{[]string{"//my/target"}, []string{"//my/target"}, nil, nil},
+		{[]string{"//my/target"}, []string{"//my/target"}, nil, nil, nil},
 		// arguments after a --.
-		{[]string{"--", "--my_program_flag"}, nil, nil, []string{"--my_program_flag"}},
+		{[]string{"--", "--my_program_flag"}, nil, nil, nil, []string{"--my_program_flag"}},
+		// Whitelisted startup argument.
+		{[]string{"--bazelrc=/home/libsamek/bazelrc"}, nil, []string{"--bazelrc=/home/libsamek/bazelrc"}, nil, nil},
 		// Whitelisted bazel flag.
-		{[]string{"--test_output=streaming"}, nil, []string{"--test_output=streaming"}, nil},
+		{[]string{"--test_output=streaming"}, nil, nil, []string{"--test_output=streaming"}, nil},
 		// Whitelisted bazel flag, arg, and target.
-		{[]string{"--test_output=streaming", "--", "--my_program_flag"}, nil, []string{"--test_output=streaming"}, []string{"--my_program_flag"}},
+		{[]string{"--test_output=streaming", "--", "--my_program_flag"}, nil, nil,[]string{"--test_output=streaming"}, []string{"--my_program_flag"}},
 	} {
-		targets, bazelArgs, args := parseArgs(c.in)
+		targets, startupArgs, bazelArgs, args := parseArgs(c.in)
 		if !reflect.DeepEqual(c.targets, targets) {
 			t.Errorf("Targets not equal for args: %v\nGot:  %v\nWant: %v",
+				c.in, targets, c.targets)
+		}
+		if !reflect.DeepEqual(c.startupArgs, startupArgs) {
+			t.Errorf("Startup arguments not equal for args: %v\nGot:  %v\nWant: %v",
 				c.in, targets, c.targets)
 		}
 		if !reflect.DeepEqual(c.bazelArgs, bazelArgs) {


### PR DESCRIPTION
As discussed in #278 adding support for `--bazelrc` option. Since this is a startup option, additional changes were needed.