### PR TITLE
Set IBAZEL=true in process env

### DIFF
--- a/e2e/simple/simple_test.go
+++ b/e2e/simple/simple_test.go
@@ -93,6 +93,27 @@ sh_binary(
 	ibazel.ExpectOutput("Started!")
 }
 
+func TestSimpleRunConfirmEnvironment(t *testing.T) {
+	b, err := bazel.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	must(t, b.ScratchFile("WORKSPACE", ""))
+	must(t, b.ScratchFileWithMode("test.sh", `printf "Started and IBAZEL=${IBAZEL}!"`, 0777))
+	must(t, b.ScratchFile("BUILD", `
+sh_binary(
+	name = "test",
+	srcs = ["test.sh"],
+)
+`))
+
+	ibazel := e2e.NewIBazelTester(t, b)
+	ibazel.Run([]string{}, "//:test")
+	defer ibazel.Kill()
+
+	ibazel.ExpectOutput("Started and IBAZEL=true!")
+}
+
 func TestSimpleRunAfterShutdown(t *testing.T) {
 	b, err := bazel.New()
 	if err != nil {

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -151,6 +151,7 @@ func main() {
 
 	command := strings.ToLower(flag.Args()[0])
 	args := flag.Args()[1:]
+	os.Setenv("IBAZEL", "true")
 
 	i, err := New()
 	if err != nil {


### PR DESCRIPTION
Thank you for making this tool!

My proposed change will allow programs to detect they are being run under
bazel-watcher.

I'd like to have this because I use a bazel wrapper script that automatically runs gazelle and does a bunch of other bazel tuning, and I want to do different things when being invoked by ibazel.

I have signed the Google Individual CLA on September 04, 2008.