### PR TITLE
Update to latest rules_go

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -38,5 +38,8 @@ platforms:
     test_flags:
     - "--test_tag_filters=-nowindows"
     - "--experimental_enable_runfiles"
+    # On Windows CI, bazel (bazelisk) needs %LocalAppData% to find the cache directory.
+    # We invoke bazel in tests, so the tests need this, too.
+    - "--test_env=LOCALAPPDATA"
     test_targets:
     - "..."

--- a/BUILD
+++ b/BUILD
@@ -20,3 +20,5 @@ gazelle(
 )
 
 exports_files(["CONTRIBUTORS"])
+
+# gazelle:resolve go github.com/bazelbuild/bazel-integration-testing/go @com_github_bazelbuild_bazel_integration_testing//go:go_default_library

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,16 +15,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "com_github_bazelbuild_bazel_integration_testing",
-    sha256 = "8601e606c315a3a12a38ca527d5a3fc4a41aff935950b0678b4b5aa9b7dd2644",
-    strip_prefix = "bazel-integration-testing-cd4f16d50898eebe0eca0c09496fe15e9a642f71",
-    url = "https://github.com/bazelbuild/bazel-integration-testing/archive/cd4f16d50898eebe0eca0c09496fe15e9a642f71.tar.gz",
-)
-load("@com_github_bazelbuild_bazel_integration_testing//tools:repositories.bzl", "bazel_binaries")
-
-bazel_binaries()
-
-http_archive(
     name = "bazel_skylib",
     sha256 = "e5d90f0ec952883d56747b7604e2a15ee36e288bb556c3d0ed33e818a4d971f2",
     strip_prefix = "bazel-skylib-1.0.2",
@@ -34,26 +24,46 @@ http_archive(
     ],
 )
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
+    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+    ],
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
+
 # NOTE: URLs are mirrored by an asynchronous review process. They must
 #       be greppable for that to happen. It's OK to submit broken mirror
 #       URLs, so long as they're correctly formatted. Bazel's downloader
 #       has fast failover.
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
+    sha256 = "b9aa86ec08a292b97ec4591cf578e020b35f98e12173bbd4a921f84f583aebd9",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.20.2/rules_go-v0.20.2.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.20.2/rules_go-v0.20.2.tar.gz",
     ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
+    sha256 = "86c6d481b3f7aedc1d60c1c211c6f76da282ae197c3b3160f54bd3a8f847896f",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
     ],
 )
 
@@ -63,51 +73,10 @@ go_rules_dependencies()
 
 go_register_toolchains()
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
 
-go_repository(
-    name = "com_github_fsnotify_fsnotify",
-    importpath = "github.com/fsnotify/fsnotify",
-    tag = "v1.4.7",
-)
+load(":repositories.bzl", "go_repositories")
 
-go_repository(
-    name = "com_github_jaschaephraim_lrserver",
-    importpath = "github.com/jaschaephraim/lrserver",
-    tag = "3.0.1",
-)
-
-go_repository(
-    name = "com_github_gorilla_websocket",
-    importpath = "github.com/gorilla/websocket",
-    tag = "v1.4.1",
-)
-
-go_repository(
-    name = "org_golang_x_sys",
-    commit = "cc5685c2db1239775905f3911f0067c0fa74762f",
-    importpath = "golang.org/x/sys",
-)
-
-# NOTE: this must match rules_go version located at
-# https://github.com/bazelbuild/rules_go/blob/master/go/private/repositories.bzl
-go_repository(
-    name = "com_github_golang_protobuf",
-    importpath = "github.com/golang/protobuf",
-    tag = "v1.3.2",
-)
-
-go_repository(
-    name = "com_github_gorilla_websocket",
-    importpath = "github.com/gorilla/websocket",
-    tag = "v1.4.0",
-)
-
-# NOTE: this must match rules_go version above
-go_repository(
-    name = "com_github_bazelbuild_rules_go",
-    importpath = "github.com/bazelbuild/rules_go",
-    tag = "v0.20.2",
-)
+go_repositories()

--- a/e2e/BUILD
+++ b/e2e/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
+# gazelle:map_kind go_test go_bazel_test @io_bazel_rules_go//go/tools/bazel_testing:def.bzl
+
 go_library(
     name = "go_default_library",
     srcs = [
@@ -10,7 +12,7 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-watcher/e2e",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_github_bazelbuild_bazel_integration_testing//go:go_default_library",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@io_bazel_rules_go//go/tools/bazel_testing:go_default_library",
     ],
 )

--- a/e2e/common.go
+++ b/e2e/common.go
@@ -2,8 +2,11 @@ package e2e
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
+	"testing"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
 )
@@ -31,4 +34,62 @@ func getiBazelPath() string {
 		suffix = ".exe"
 	}
 	return GetPath(fmt.Sprintf("ibazel/%s_%s_pure_stripped/ibazel%s", runtime.GOOS, runtime.GOARCH, suffix))
+}
+
+func Must(t *testing.T, e error) {
+	t.Helper()
+	if e != nil {
+		t.Fatalf("Error: %s", e)
+		//t.Logf("Stack trace:\n%s", string(debug.Stack()))
+	}
+}
+
+func MustMkdir(t *testing.T, path string, mode ...os.FileMode) {
+	t.Helper()
+
+	m := os.FileMode(0777)
+	if len(mode) == 1 {
+		m = mode[0]
+	}
+
+	if err := os.MkdirAll(path, m); err != nil {
+		t.Fatalf("os.MkdirAll(%q, %d): %v", path, m, err)
+	}
+}
+
+func MustWriteFile(t *testing.T, path, content string, mode ...os.FileMode) {
+	t.Helper()
+
+	m := os.FileMode(0777)
+	if len(mode) == 1 {
+		m = mode[0]
+	}
+
+	if err := ioutil.WriteFile(path, []byte(content), m); err != nil {
+		t.Fatalf("ioutil.WriteFile(%q, []byte(%q), 0777): %v", path, content, err)
+	}
+}
+
+func SetExecuteBit(t *testing.T) {
+	// Before doing anything, set the executable bit on all the .sh files
+	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if err := os.Chmod(path, 0777); err != nil {
+			t.Fatalf("Error os.Chmod(%q, 0777): %v", path, err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("filpath.Walk(): %v", err)
+	}
+}
+
+func SetUp(t *testing.T) *IBazelTester {
+	SetExecuteBit(t)
+	return NewIBazelTester(t)
 }

--- a/e2e/error/BUILD
+++ b/e2e/error/BUILD
@@ -2,11 +2,11 @@ load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 
 go_bazel_test(
     name = "go_default_test",
-    srcs = ["simple_test.go"],
+    srcs = ["error_test.go"],
     data = [
         "//ibazel",
     ],
-    importpath = "github.com/bazelbuild/bazel-watcher/e2e/simple",
+    importpath = "github.com/bazelbuild/bazel-watcher/e2e/error",
     deps = [
         "//bazel:go_default_library",
         "//e2e:go_default_library",

--- a/e2e/error/error_test.go
+++ b/e2e/error/error_test.go
@@ -1,0 +1,44 @@
+package error
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/bazel-watcher/e2e"
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{})
+}
+
+func TestSimpleBuildWithoutSourceFiles(t *testing.T) {
+	e2e.MustWriteFile(t, "BUILD", `
+# Invalid rule due to a missing input file
+sh_binary(
+  name = "test",
+  srcs = ["test.sh"],
+)
+`)
+
+	ibazel := e2e.SetUp(t)
+	ibazel.Build("//:test")
+	defer ibazel.Kill()
+
+	ibazel.ExpectError("//:test: missing input file '//:test.sh'")
+}
+
+func TestSimpleBuildWithQueryFailure(t *testing.T) {
+	e2e.MustWriteFile(t, "BUILD", `
+# Invalid rule due to a typo
+shh_binary(
+  name = "test",
+  srcs = ["test.sh"],
+)
+`)
+
+	ibazel := e2e.SetUp(t)
+	ibazel.Build("//:test")
+	defer ibazel.Kill()
+
+	ibazel.ExpectError("name 'shh_binary' is not defined")
+}

--- a/e2e/ibazel.go
+++ b/e2e/ibazel.go
@@ -1,90 +1,148 @@
 package e2e
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime/debug"
 	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
-	bazel "github.com/bazelbuild/bazel-integration-testing/go"
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
 )
 
 // Maximum amount of time to wait before failing a test for not matching your expectations.
-var delay = 20 * time.Second
+const (
+	defaultDelay = 20 * time.Second
+)
+
+var (
+	ibazelLogFile = filepath.Join(os.TempDir(), "ibazel_output.log")
+)
 
 type IBazelTester struct {
-	bazel *bazel.TestingBazel
-	t     *testing.T
+	t *testing.T
 
 	cmd          *exec.Cmd
 	stderrBuffer *Buffer
 	stderrOld    string
 	stdoutBuffer *Buffer
 	stdoutOld    string
+	ibazelErrOld string
 }
 
-func NewIBazelTester(t *testing.T, bazel *bazel.TestingBazel) *IBazelTester {
+func NewIBazelTester(t *testing.T) *IBazelTester {
 	return &IBazelTester{
-		bazel: bazel,
-		t:     t,
+		t: t,
 	}
 }
 
 func (i *IBazelTester) bazelPath() string {
-	return i.bazel.GetBazel()
+	i.t.Helper()
+	path, err := exec.LookPath("bazel")
+	if err != nil {
+		i.t.Fatalf("Unable to find bazel binary: %v", err)
+	}
+	return path
 }
 
 func (i *IBazelTester) Build(target string) {
+	i.t.Helper()
 	i.build(target, []string{})
 }
 
 func (i *IBazelTester) Run(bazelArgs []string, target string) {
-	i.run(target, bazelArgs, []string{})
+	i.t.Helper()
+	i.run(target, bazelArgs, []string{
+		"--log_to_file=" + ibazelLogFile,
+	})
 }
 
 func (i *IBazelTester) RunWithProfiler(target string, profiler string) {
-	i.run(target, []string{}, []string{"--profile_dev=" + profiler})
+	i.t.Helper()
+	i.run(target, []string{}, []string{
+		"--log_to_file=" + ibazelLogFile,
+		"--profile_dev=" + profiler,
+	})
 }
 
 func (i *IBazelTester) RunWithBazelFixCommands(target string) {
+	i.t.Helper()
 	i.run(target, []string{}, []string{
+		"--log_to_file=" + ibazelLogFile,
 		"--run_output=true",
 		"--run_output_interactive=false",
 	})
 }
 
 func (i *IBazelTester) GetOutput() string {
+	i.t.Helper()
 	return i.stdoutBuffer.String()
 }
 
-func (i *IBazelTester) ExpectOutput(want string) {
-	i.Expect(want, i.GetOutput, &i.stdoutOld)
+func (i *IBazelTester) ExpectOutput(want string, delay ...time.Duration) {
+	i.t.Helper()
+
+	i.checkExit()
+
+	d := defaultDelay
+	if len(delay) == 1 {
+		d = delay[0]
+	}
+	i.Expect(want, i.GetOutput, &i.stdoutOld, d)
 }
 
-func (i *IBazelTester) ExpectError(want string) {
-	i.Expect(want, i.GetError, &i.stderrOld)
+func (i *IBazelTester) ExpectError(want string, delay ...time.Duration) {
+	i.t.Helper()
+
+	i.checkExit()
+
+	d := defaultDelay
+	if len(delay) == 1 {
+		d = delay[0]
+	}
+	i.Expect(want, i.GetError, &i.stderrOld, d)
 }
 
-func (i *IBazelTester) ExpectIBazelError(want string) {
+func (i *IBazelTester) ExpectIBazelError(want string, delay ...time.Duration) {
+	i.t.Helper()
+
+	i.checkExit()
+
+	d := defaultDelay
+	if len(delay) == 1 {
+		d = delay[0]
+	}
+	i.Expect(want, i.GetIBazelError, &i.ibazelErrOld, d)
 }
 
 func (i *IBazelTester) GetIBazelError() string {
-	iBazelError, err := os.Open("/tmp/ibazel_output.log")
+	i.t.Helper()
+
+	i.checkExit()
+
+	iBazelError, err := os.Open(ibazelLogFile)
+	if err != nil {
+		i.t.Errorf("Error os.Open(%q): %v", ibazelLogFile, err)
+		return ""
+	}
 
 	b, err := ioutil.ReadAll(iBazelError)
 	if err != nil {
-		i.t.Fatal(err)
+		i.t.Fatalf("Error ioutil.ReadAll(iBazelError): %v", err)
 	}
 
 	return string(b)
 }
 
-func (i *IBazelTester) Expect(want string, stream func() string, history *string) {
+func (i *IBazelTester) Expect(want string, stream func() string, history *string, delay time.Duration) {
+	i.t.Helper()
+
 	stopAt := time.Now().Add(delay)
 	for time.Now().Before(stopAt) {
 		time.Sleep(5 * time.Millisecond)
@@ -101,7 +159,8 @@ func (i *IBazelTester) Expect(want string, stream func() string, history *string
 
 	if match, err := regexp.MatchString(want, stream()); match == false || err != nil {
 		i.t.Errorf("Expected iBazel output after %v to be:\nWanted [%v], got [%v]", delay, want, stream())
-		i.t.Log(string(debug.Stack()))
+		i.t.Errorf("Stderr: [%v]\niBazelStderr: [%v]", i.GetError(), i.GetIBazelError())
+		//i.t.Log(string(debug.Stack()))
 
 		// In order to prevent cascading errors where the first result failing to
 		// match ruins the error output for the rest of the runs, persist the old
@@ -111,10 +170,12 @@ func (i *IBazelTester) Expect(want string, stream func() string, history *string
 }
 
 func (i *IBazelTester) GetError() string {
+	i.t.Helper()
 	return i.stderrBuffer.String()
 }
 
 func (i *IBazelTester) GetSubprocessPid() int64 {
+	i.t.Helper()
 	f, err := os.Open(filepath.Join(os.TempDir(), "ibazel_e2e_subprocess_launcher.pid"))
 	if err != nil {
 		panic(err)
@@ -133,12 +194,14 @@ func (i *IBazelTester) GetSubprocessPid() int64 {
 }
 
 func (i *IBazelTester) Kill() {
+	i.t.Helper()
 	if err := i.cmd.Process.Kill(); err != nil {
 		panic(err)
 	}
 }
 
 func (i *IBazelTester) build(target string, additionalArgs []string) {
+	i.t.Helper()
 	args := []string{"--bazel_path=" + i.bazelPath()}
 	args = append(args, additionalArgs...)
 	args = append(args, "build")
@@ -152,22 +215,40 @@ func (i *IBazelTester) build(target string, additionalArgs []string) {
 	i.cmd.Stderr = i.stderrBuffer
 
 	if err := i.cmd.Start(); err != nil {
-		i.t.Logf("Command: %s", i.cmd)
-		panic(err)
+		i.t.Fatalf("Command: %s\nError: %v", i.cmd, err)
+	}
+}
+
+func (i *IBazelTester) checkExit() {
+	if i.cmd != nil && i.cmd.ProcessState != nil && i.cmd.ProcessState.Exited() == true {
+		i.t.Errorf("ibazel is exited")
 	}
 }
 
 func (i *IBazelTester) run(target string, bazelArgs []string, additionalArgs []string) {
+	i.t.Helper()
+
 	args := []string{"--bazel_path=" + i.bazelPath()}
 	args = append(args, additionalArgs...)
 	args = append(args, "run")
 	args = append(args, target)
 	args = append(args, bazelArgs...)
 	i.cmd = exec.Command(ibazelPath, args...)
+	i.t.Logf("ibazel invoked as: %s", strings.Join(i.cmd.Args, " "))
 
-	errCode, buildStdout, buildStderr := i.bazel.RunBazel([]string{"build", target})
-	if errCode != 0 {
-		i.t.Fatalf("Unable to build target. Error code: %d\nStdout:\n%s\nStderr:\n%s", errCode, buildStdout, buildStderr)
+	cmd := bazel_testing.BazelCmd("build", target)
+
+	var buildStdout, buildStderr bytes.Buffer
+	cmd.Stdout = &buildStdout
+	cmd.Stderr = &buildStderr
+
+	// Before doing anything crazy, let's build the target to make sure it works.
+
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			status := exitErr.Sys().(syscall.WaitStatus)
+			i.t.Fatalf("Unable to build target. Error code: %d\nStdout:\n%s\nStderr:\n%s", status.ExitStatus(), buildStdout.String(), buildStderr.String())
+		}
 	}
 
 	i.stdoutBuffer = &Buffer{}

--- a/e2e/live_reload/BUILD
+++ b/e2e/live_reload/BUILD
@@ -1,19 +1,14 @@
-# gazelle:exclude live_reload_test.go
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 
-load("@com_github_bazelbuild_bazel_integration_testing//go:bazel_integration_test.bzl", "bazel_go_integration_test")
-load("@com_github_bazelbuild_bazel_integration_testing//tools:common.bzl", "GET_LATEST_BAZEL_VERSIONS")
-
-bazel_go_integration_test(
+go_bazel_test(
     name = "go_default_test",
     srcs = ["live_reload_test.go"],
     data = [
         "//ibazel",
     ],
     importpath = "github.com/bazelbuild/bazel-watcher/e2e/live_reload",
-    versions = GET_LATEST_BAZEL_VERSIONS(),
     deps = [
         "//e2e:go_default_library",
-        "@com_github_bazelbuild_bazel_integration_testing//go:go_default_library",
         "@com_github_gorilla_websocket//:go_default_library",
     ],
 )

--- a/e2e/output_runner/BUILD
+++ b/e2e/output_runner/BUILD
@@ -1,16 +1,13 @@
-load("@com_github_bazelbuild_bazel_integration_testing//go:bazel_integration_test.bzl", "bazel_go_integration_test")
-load("@com_github_bazelbuild_bazel_integration_testing//tools:common.bzl", "GET_LATEST_BAZEL_VERSIONS")
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 
-bazel_go_integration_test(
+go_bazel_test(
     name = "go_default_test",
     srcs = ["output_runner_test.go"],
     data = [
         "//ibazel",
     ],
     importpath = "github.com/bazelbuild/bazel-watcher/e2e/output_runner",
-    versions = GET_LATEST_BAZEL_VERSIONS(),
     deps = [
         "//e2e:go_default_library",
-        "@com_github_bazelbuild_bazel_integration_testing//go:go_default_library",
     ],
 )

--- a/e2e/output_runner/output_runner_test.go
+++ b/e2e/output_runner/output_runner_test.go
@@ -4,131 +4,129 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"runtime/debug"
 	"strings"
 	"testing"
 
-	bazel "github.com/bazelbuild/bazel-integration-testing/go"
 	"github.com/bazelbuild/bazel-watcher/e2e"
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
 )
 
-func must(t *testing.T, e error) {
-	if e != nil {
-		t.Errorf("Error: %s\n", e)
-		t.Logf("Stack:\n%s", string(debug.Stack()))
-	}
+const mainFiles = `
+-- defs.bzl --
+def fix_deps():
+  print("runacommand")
+-- BUILD --
+load("//:defs.bzl", "fix_deps")
+
+fix_deps()
+
+sh_binary(
+  name = "test",
+  srcs = ["test.sh"],
+)
+
+sh_binary(
+  name = "overwrite",
+  srcs = ["overwrite.sh"],
+)
+-- test.sh --
+printf "action"
+-- overwrite.sh --
+printf "overwrite"
+`
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: mainFiles,
+	})
 }
 
 func checkNoSentinel(t *testing.T, sentinelFile *os.File, msg string) {
+	t.Helper()
+
 	if _, err := os.Stat(sentinelFile.Name()); !os.IsNotExist(err) {
-		must(t, fmt.Errorf("Found a sentinel when expecting none: %s\n", msg))
+		t.Errorf("Found a sentinel when expecting none: %s\n", msg)
 	}
 }
 
 func checkSentinel(t *testing.T, sentinelFile *os.File, msg string) {
-	if _, err := os.Stat(sentinelFile.Name()); os.IsNotExist(err) {
-		t.Error(err)
-		must(t, fmt.Errorf("Couldn't find a sentinel: %s\n%s\n", msg, err))
+	t.Helper()
+
+	sentinalFileName := sentinelFile.Name()
+	if _, err := os.Stat(sentinalFileName); os.IsNotExist(err) {
+		t.Errorf("Couldn't find sentinal. os.Stat(%q): %s\n%s\n", sentinalFileName, err, msg)
 	}
 
 	os.Remove(sentinelFile.Name())
 }
 
 func TestOutputRunner(t *testing.T) {
-	b, err := bazel.New()
-	if err != nil {
-		t.Fatal(err)
-	}
+	e2e.SetExecuteBit(t)
 
 	sentinelFile, err := ioutil.TempFile("", "fixCommandSentinel")
-	must(t, err)
-	must(t, sentinelFile.Close())
+	if err != nil {
+		t.Errorf("ioutil.TempFile(\"\", \"fixCommandSentinel\": %v", err)
+	}
+	sentinalFileName := strings.Replace(sentinelFile.Name(), "\\", "/", -1)
+
+	e2e.Must(t, sentinelFile.Close())
 	checkSentinel(t, sentinelFile, "ioutil.TempFile creates the file by default. Delete it.")
 	checkNoSentinel(t, sentinelFile, "The sentinal should now be deleted.")
 
-	must(t, b.ScratchFile(".bazel_fix_commands.json", fmt.Sprintf(`
-[{
-	"regex": "^(.*)runacommand(.*)$",
-	"command": "touch",
-	"args": ["%s"]
-}]
-`, strings.Replace(sentinelFile.Name(), "\\", "/", -1))))
-	must(t, b.ScratchFile("WORKSPACE", ""))
-	must(t, b.ScratchFileWithMode("test.sh", `printf "action"`, 0777))
-	must(t, b.ScratchFile("defs.bzl", `
-def doit():
-  print("runacommand")
-`))
-	must(t, b.ScratchFile("BUILD", `
-load("//:defs.bzl", "doit")
+	e2e.MustWriteFile(t, ".bazel_fix_commands.json", fmt.Sprintf(`
+	[{
+		"regex": "^(.*)runacommand(.*)$",
+		"command": "touch",
+		"args": ["%s"]
+	}]`, sentinalFileName))
 
-doit()
+	e2e.MustWriteFile(t, "overwrite.sh", `
+printf "overwrite1"
+`)
 
-sh_binary(
-  name = "test",
-  srcs = ["test.sh"],
-)
-`))
+	ibazel := e2e.NewIBazelTester(t)
+	ibazel.RunWithBazelFixCommands("//:overwrite")
 
-	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.RunWithBazelFixCommands("//:test")
-
-	ibazel.ExpectOutput("action")
+	ibazel.ExpectOutput("overwrite1")
 	checkSentinel(t, sentinelFile, "The first run should create a sentinel.")
 
 	ibazel.Kill()
 
-	// TODO: Running the test a second time fails. I think there is a bug in the way
-	// buffers are registered and they are lost between runs. Interestingly it
-	// works if you reinvoke ibazel.
-	ibazel = e2e.NewIBazelTester(t, b)
-	ibazel.RunWithBazelFixCommands("//:test")
+	// Invoke the test a 2nd time to ensure it works over multiple separate
+	// invocations of ibazel.
+	ibazel = e2e.NewIBazelTester(t)
+	ibazel.RunWithBazelFixCommands("//:overwrite")
+	ibazel.ExpectOutput("overwrite1")
+	checkSentinel(t, sentinelFile, "The second run should create a sentinel.")
 
-	ibazel.ExpectOutput("action")
-	checkSentinel(t, sentinelFile, "The first run should create a sentinel.")
+	// TODO: Figure out why the 2nd invocation doesn't touch the file.
+	// Test that the command is run again.
+	//e2e.MustWriteFile(t, "overwrite.sh", `printf "overwrite2"`)
 
-	ibazel.Kill()
+	//ibazel.ExpectOutput("overwrite2")
+	//checkSentinel(t, sentinelFile, "The third run should create a sentinel.")
 
-	//// Test that the command is run again.
-	//must(t, b.ScratchFileWithMode("test.sh", `printf "action"`, 0777))
-
-	//ibazel.ExpectOutput("action2")
-	//checkSentinel(t, sentinelFile, "The second run should create a sentinel.")
-
-	// Now remove the print and it shouldn't fire.
-	must(t, b.ScratchFile("defs.bzl", `
-def doit():
+	// Now replace the print and it shouldn't fire.
+	e2e.MustWriteFile(t, "defs.bzl", `
+def fix_deps():
   print("not it")
-`))
+`)
 
-	ibazel.ExpectOutput("action")
+	ibazel.ExpectOutput("overwrite1")
 	checkNoSentinel(t, sentinelFile, "The third run should not create a sentinel.")
 }
 
 func TestNotifyWhenInvalidConfig(t *testing.T) {
-	b, err := bazel.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	must(t, b.ScratchFile(".bazel_fix_commands.json", `
+	e2e.MustWriteFile(t, ".bazel_fix_commands.json", `
 invalid json file
-`))
-	must(t, b.ScratchFile("WORKSPACE", ""))
-	must(t, b.ScratchFileWithMode("test.sh", `printf "Hello world"`, 0777))
-	must(t, b.ScratchFile("BUILD", `
-sh_binary(
-	name = "test",
-	srcs = ["test.sh"],
-)
-`))
+`)
 
-	ibazel := e2e.NewIBazelTester(t, b)
+	ibazel := e2e.SetUp(t)
 	ibazel.RunWithBazelFixCommands("//:test")
 	defer ibazel.Kill()
 
 	// It should run the program and print out an error that says your JSON is
 	// invalid.
 	ibazel.ExpectIBazelError("Error in .bazel_fix_commands.json")
-	ibazel.ExpectOutput("Hello world")
+	ibazel.ExpectOutput("action")
 }

--- a/e2e/profiler/BUILD
+++ b/e2e/profiler/BUILD
@@ -1,19 +1,15 @@
-# gazelle:exclude profiler_test.go
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 
-load("@com_github_bazelbuild_bazel_integration_testing//go:bazel_integration_test.bzl", "bazel_go_integration_test")
-load("@com_github_bazelbuild_bazel_integration_testing//tools:common.bzl", "GET_LATEST_BAZEL_VERSIONS")
-
-bazel_go_integration_test(
+go_bazel_test(
     name = "go_default_test",
     srcs = ["profiler_test.go"],
     data = [
         "//ibazel",
     ],
     importpath = "github.com/bazelbuild/bazel-watcher/e2e/profiler",
-    versions = GET_LATEST_BAZEL_VERSIONS(),
     deps = [
         "//e2e:go_default_library",
-        "@com_github_bazelbuild_bazel_integration_testing//go:go_default_library",
         "@com_github_gorilla_websocket//:go_default_library",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/e2e/simple/simple_test.go
+++ b/e2e/simple/simple_test.go
@@ -2,346 +2,180 @@ package simple
 
 import (
 	"errors"
-	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
-	"runtime/debug"
+	"os/exec"
+	"path/filepath"
+	"syscall"
 	"testing"
 
-	bazel "github.com/bazelbuild/bazel-integration-testing/go"
 	"github.com/bazelbuild/bazel-watcher/e2e"
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
 )
 
-func must(t *testing.T, e error) {
-	if e != nil {
-		t.Fatalf("Error: %s", e)
-		t.Logf("Stack trace:\n%s", string(debug.Stack()))
-	}
+const mainFiles = `
+-- BUILD.bazel --
+# Base case test
+sh_binary(
+  name = "simple",
+  srcs = ["simple.sh"],
+)
+
+# Environment variable tests
+sh_binary(
+  name = "environment",
+  srcs = ["environment.sh"],
+)
+
+# --define tests
+config_setting(
+  name = "test_is_2",
+  values = {"define": "test_number=2"},
+)
+
+sh_binary(
+  name = "define",
+  srcs = select({
+        ":test_is_2": ["define_test_2.sh"],
+        "//conditions:default": ["define_test_1.sh"],
+    }),
+)
+-- simple.sh --
+printf "Started!"
+-- environment.sh --
+printf "Started and IBAZEL=${IBAZEL}!"
+-- define_test_1.sh --
+printf "define_test_1"
+-- define_test_2.sh --
+printf "define_test_2"
+`
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: mainFiles,
+	})
 }
 
-func TestSimpleBuildWithoutSourceFiles(t *testing.T) {
-	b, err := bazel.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	must(t, b.ScratchFile("WORKSPACE", ""))
-	must(t, b.ScratchFile("BUILD", `
-sh_binary(
-	name = "test",
-	srcs = ["test.sh"], # test.sh doesn't exist
-)
-`))
-
-	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Build("//:test")
+func TestSimpleBuild(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	ibazel.Run([]string{}, "//:simple")
 	defer ibazel.Kill()
 
-	ibazel.ExpectError("Didn't find any files to watch from query " +
-		"kind\\('source file', deps\\(set\\(//:test\\)\\)\\)")
+	ibazel.ExpectOutput("Started!")
 }
 
-func TestSimpleBuildWithQueryFailure(t *testing.T) {
-	b, err := bazel.New()
-	if err != nil {
-		t.Fatal(err)
+func TestSimpleRunAfterShutdown(t *testing.T) {
+	cmd := bazel_testing.BazelCmd("shutdown")
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			status := exitErr.Sys().(syscall.WaitStatus)
+			if status.ExitStatus() != 0 {
+				t.Fatal(errors.New("bazel failed to shut down"))
+			}
+		}
 	}
-	must(t, b.ScratchFile("WORKSPACE", ""))
-	must(t, b.ScratchFileWithMode("test.sh", `printf "Started!"`, 0777))
-	must(t, b.ScratchFile("BUILD", `
-# Invalid rule due to a typo
-shh_binary(
-	name = "test",
-	srcs = ["test.sh"],
-)
-`))
 
-	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Build("//:test")
-	defer ibazel.Kill()
-
-	ibazel.ExpectError("Bazel query failed")
-
-	must(t, b.ScratchFile("BUILD", `
-# Fixed the typo
-sh_binary(
-	name = "test",
-	srcs = ["test.sh"],
-)
-`))
-
-	ibazel.ExpectError("Build completed successfully")
-}
-
-func TestSimpleRun(t *testing.T) {
-	b, err := bazel.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	must(t, b.ScratchFile("WORKSPACE", ""))
-	must(t, b.ScratchFileWithMode("test.sh", `printf "Started!"`, 0777))
-	must(t, b.ScratchFile("BUILD", `
-sh_binary(
-	name = "test",
-	srcs = ["test.sh"],
-)
-`))
-
-	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run([]string{}, "//:test")
+	ibazel := e2e.SetUp(t)
+	ibazel.Run([]string{}, "//:simple")
 	defer ibazel.Kill()
 
 	ibazel.ExpectOutput("Started!")
 }
 
 func TestSimpleRunConfirmEnvironment(t *testing.T) {
-	b, err := bazel.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	must(t, b.ScratchFile("WORKSPACE", ""))
-	must(t, b.ScratchFileWithMode("test.sh", `printf "Started and IBAZEL=${IBAZEL}!"`, 0777))
-	must(t, b.ScratchFile("BUILD", `
-sh_binary(
-	name = "test",
-	srcs = ["test.sh"],
-)
-`))
-
-	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run([]string{}, "//:test")
+	ibazel := e2e.SetUp(t)
+	ibazel.Run([]string{}, "//:environment")
 	defer ibazel.Kill()
 
 	ibazel.ExpectOutput("Started and IBAZEL=true!")
 }
 
-func TestSimpleRunAfterShutdown(t *testing.T) {
-	b, err := bazel.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	must(t, b.ScratchFile("WORKSPACE", ""))
-	must(t, b.ScratchFileWithMode("test.sh", `printf "Started!"`, 0777))
-	must(t, b.ScratchFile("BUILD", `
-sh_binary(
-	name = "test",
-	srcs = ["test.sh"],
-)
-`))
-
-	errCode, _, _ := b.RunBazel([]string{"shutdown"})
-	if errCode != 0 {
-		t.Fatal(errors.New("bazel failed to shut down"))
-	}
-
-	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run([]string{}, "//:test")
-	defer ibazel.Kill()
-
-	ibazel.ExpectOutput("Started!")
-}
-
 func TestSimpleRunUnderSubdir(t *testing.T) {
-	b, err := bazel.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	must(t, b.ScratchFile("WORKSPACE", ""))
-	must(t, b.ScratchDir("subdir"))
-	must(t, b.ScratchFileWithMode("subdir/test.sh", `printf "Started!"`, 0777))
-	must(t, b.ScratchFile("subdir/BUILD", `
+	// TODO: the logic to create these directories is unnecessary after
+	// https://github.com/bazelbuild/rules_go/pull/2280 When that happens, make
+	// these dirs and files in the txtar during setup.
+	subdir := "subdir"
+
+	e2e.Must(t, os.Mkdir(subdir, 0777))
+	e2e.MustWriteFile(t, filepath.Join(subdir, "BUILD.bazel"), `
 sh_binary(
-	name = "test",
-	srcs = ["test.sh"],
+  name = "subdir",
+  srcs = ["subdir.sh"],
 )
-`))
+`)
+	e2e.MustWriteFile(t, filepath.Join(subdir, "subdir.sh"), `
+printf "Hello subdir!"
+`, 0777)
 
-	ibazel := e2e.NewIBazelTester(t, b)
+	// END TODO
 
-	err = os.Chdir("subdir")
+	ibazel := e2e.SetUp(t)
+
+	err := os.Chdir(subdir)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Error os.Chdir(%q): %v", subdir, err)
 	}
+	defer func() {
+		err := os.Chdir("..")
+		if err != nil {
+			t.Fatalf("Error os.Chdir(\"..\"): %v", err)
+		}
+	}()
 
-	ibazel.Run([]string{}, "test")
+	ibazel.Run([]string{}, "//subdir")
 	defer ibazel.Kill()
 
-	err = os.Chdir("..")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ibazel.ExpectOutput("Started!")
+	ibazel.ExpectOutput("Hello subdir")
 }
 
 func TestSimpleRunWithModifiedFile(t *testing.T) {
-	b, err := bazel.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	must(t, b.ScratchFile("WORKSPACE", ""))
-	must(t, b.ScratchFileWithMode("test.sh", `printf "Started!"`, 0777))
-	must(t, b.ScratchFile("BUILD", `
-sh_binary(
-	name = "test",
-	srcs = ["test.sh"],
-)
-`))
-
-	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run([]string{}, "//:test")
+	ibazel := e2e.SetUp(t)
+	ibazel.Run([]string{}, "//:simple")
 	defer ibazel.Kill()
 
+	ibazel.ExpectOutput("Started!")
+
 	// Give it time to start up and query.
-	must(t, b.ScratchFileWithMode("test.sh", `printf "Started2!"`, 0777))
+	e2e.MustWriteFile(t, "simple.sh", `printf "Started2!"`)
 	ibazel.ExpectOutput("Started2!")
 
 	// Manipulate a source file and sleep past the debounce.
-	must(t, b.ScratchFileWithMode("test.sh", `printf "Started3!"`, 0777))
+	e2e.MustWriteFile(t, "simple.sh", `printf "Started3!"`)
 	ibazel.ExpectOutput("Started3!")
 
-	// Now a BUILD file.
-	must(t, b.ScratchFile("BUILD", `
+	// TODO: put these in directories instead of storing the old value and rewriting it
+	oldValue, err := ioutil.ReadFile("BUILD.bazel")
+	if err != nil {
+		t.Errorf("Unable to Readfile(\"BUILD.bazel\"): %v", err)
+	}
+	defer e2e.MustWriteFile(t, "BUILD.bazel", string(oldValue))
+	// END TODO
+
+	// Now a BUILD.bazel file.
+	e2e.MustWriteFile(t, "BUILD.bazel", `
 sh_binary(
 	# New comment
 	name = "test",
 	srcs = ["test.sh"],
 )
-`))
+`)
 	ibazel.ExpectOutput("Started3!")
 }
 
 func TestSimpleRunWithFlag(t *testing.T) {
-	b, err := bazel.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	must(t, b.ScratchFile("WORKSPACE", ""))
-	must(t, b.ScratchFileWithMode("test_1.sh", `printf "Started 1!"`, 0777))
-	must(t, b.ScratchFileWithMode("test_2.sh", `printf "Started 2!"`, 0777))
-	must(t, b.ScratchFile("BUILD", `
-config_setting(
-	name = "test_is_2",
-	values = {"define": "test_number=2"},
-)
+	ibazel := e2e.SetUp(t)
 
-sh_binary(
-	name = "test",
-	srcs = select({
-        ":test_is_2": ["test_2.sh"],
-        "//conditions:default": ["test_1.sh"],
-    }),
-)
-`))
+	ibazel.Run([]string{}, "//:define")
+	ibazel.ExpectOutput("define_test_1")
+	ibazel.Kill()
 
-	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run([]string{"--define=test_number=2"}, "//:test")
-	defer ibazel.Kill()
+	ibazel = e2e.NewIBazelTester(t)
+	ibazel.Run([]string{"--define=test_number=2"}, "//:define")
+	ibazel.ExpectOutput("define_test_2")
+	ibazel.Kill()
 
-	ibazel.ExpectOutput("Started 2!")
-}
-
-func renameAndWriteNewFile(t *testing.T, fname, content string) {
-	// write a file in the same manner as vim with backupcopy=no;
-	// this will rename the original file to a file with a backup extension
-	// and write the new file contents to the original filename
-
-	fnameBackup := fmt.Sprintf("%s~", fname)
-	must(t, os.Rename(fname, fnameBackup))
-	f, err := os.OpenFile(fname, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0777)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = f.Write([]byte(content))
-	if err != nil {
-		t.Fatal(err)
-	}
-	must(t, f.Close())
-	must(t, os.Remove(fnameBackup))
-}
-
-func copyAndTruncWriteFile(t *testing.T, fname string, content string) {
-	// write a file in the same manner as vim with backupcopy=yes;
-	// this will copy the file to a suffixed backup file,
-	// truncate the existing file and write the new content
-	fnameBackup := fmt.Sprintf("%s~", fname)
-
-	f, err := os.Open(fname)
-	if err != nil {
-		t.Fatal(err)
-	}
-	fBackup, err := os.OpenFile(fnameBackup, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = io.Copy(fBackup, f)
-	if err != nil {
-		t.Fatal(err)
-	}
-	must(t, fBackup.Close())
-	must(t, f.Close())
-
-	f, err = os.OpenFile(fname, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = f.Write([]byte(content))
-	if err != nil {
-		t.Fatal(err)
-	}
-	must(t, f.Sync())
-	must(t, f.Close())
-	must(t, os.Remove(fnameBackup))
-}
-
-func TestSimpleRunWithModifiedFile_RenameAndWrite(t *testing.T) {
-	b, err := bazel.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	must(t, b.ScratchFile("WORKSPACE", ""))
-	must(t, b.ScratchFileWithMode("test.sh", `printf "Started!"`, 0777))
-	must(t, b.ScratchFile("BUILD", `
-sh_binary(
-	name = "test",
-	srcs = ["test.sh"],
-)
-`))
-
-	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run([]string{}, "//:test")
-	defer ibazel.Kill()
-	ibazel.ExpectOutput("Started!")
-
-	renameAndWriteNewFile(t, "test.sh", `printf "Started2!"`)
-	ibazel.ExpectOutput("Started2!")
-
-	renameAndWriteNewFile(t, "test.sh", `printf "Started3!"`)
-	ibazel.ExpectOutput("Started3!")
-}
-
-func TestSimpleRunWithModifiedFile_CopyAndTruncWrite(t *testing.T) {
-	b, err := bazel.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	must(t, b.ScratchFile("WORKSPACE", ""))
-	must(t, b.ScratchFileWithMode("test.sh", `printf "Started!"`, 0777))
-	must(t, b.ScratchFile("BUILD", `
-sh_binary(
-	name = "test",
-	srcs = ["test.sh"],
-)
-`))
-
-	ibazel := e2e.NewIBazelTester(t, b)
-	ibazel.Run([]string{}, "//:test")
-	defer ibazel.Kill()
-	ibazel.ExpectOutput("Started!")
-
-	copyAndTruncWriteFile(t, "test.sh", `printf "Started2!"`)
-	ibazel.ExpectOutput("Started2!")
-
-	copyAndTruncWriteFile(t, "test.sh", `printf "Started3!"`)
-	ibazel.ExpectOutput("Started3!")
+	ibazel = e2e.NewIBazelTester(t)
+	ibazel.Run([]string{}, "//:define")
+	ibazel.ExpectOutput("define_test_1")
+	ibazel.Kill()
 }

--- a/e2e/vim/BUILD
+++ b/e2e/vim/BUILD
@@ -2,11 +2,11 @@ load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
 
 go_bazel_test(
     name = "go_default_test",
-    srcs = ["simple_test.go"],
+    srcs = ["vim.go"],
     data = [
         "//ibazel",
     ],
-    importpath = "github.com/bazelbuild/bazel-watcher/e2e/simple",
+    importpath = "github.com/bazelbuild/bazel-watcher/e2e/vim",
     deps = [
         "//bazel:go_default_library",
         "//e2e:go_default_library",

--- a/e2e/vim/README.md
+++ b/e2e/vim/README.md
@@ -1,0 +1,7 @@
+# Vim tests
+
+Vim has some interesting behavior in writing files to disk. These tests verify
+that iBazel handles that correctly by simulating the exact actions of vim.
+
+If you encounter additional edge cases in the way Vim (or any other editor)
+writes files to disk, this is a great place to put them.

--- a/e2e/vim/vim.go
+++ b/e2e/vim/vim.go
@@ -1,0 +1,113 @@
+package simple
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/bazel-watcher/e2e"
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{})
+}
+
+func renameAndWriteNewFile(t *testing.T, fname, content string) {
+	// write a file in the same manner as vim with backupcopy=no;
+	// this will rename the original file to a file with a backup extension
+	// and write the new file contents to the original filename
+
+	fnameBackup := fmt.Sprintf("%s~", fname)
+	e2e.Must(t, os.Rename(fname, fnameBackup))
+	f, err := os.OpenFile(fname, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = f.Write([]byte(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	e2e.Must(t, f.Close())
+	e2e.Must(t, os.Remove(fnameBackup))
+}
+
+func copyAndTruncWriteFile(t *testing.T, fname string, content string) {
+	// write a file in the same manner as vim with backupcopy=yes;
+	// this will copy the file to a suffixed backup file,
+	// truncate the existing file and write the new content
+	fnameBackup := fmt.Sprintf("%s~", fname)
+
+	f, err := os.Open(fname)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fBackup, err := os.OpenFile(fnameBackup, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = io.Copy(fBackup, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e2e.Must(t, fBackup.Close())
+	e2e.Must(t, f.Close())
+
+	f, err = os.OpenFile(fname, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = f.Write([]byte(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	e2e.Must(t, f.Sync())
+	e2e.Must(t, f.Close())
+	e2e.Must(t, os.Remove(fnameBackup))
+}
+
+func TestSimpleRunWithModifiedFile_RenameAndWrite(t *testing.T) {
+	e2e.MustMkdir(t, "vim")
+	e2e.MustWriteFile(t, "vim/test.sh", `printf "Started!"`)
+	e2e.MustWriteFile(t, "vim/BUILD", `
+sh_binary(
+	name = "test",
+	srcs = ["test.sh"],
+)
+`)
+
+	ibazel := e2e.NewIBazelTester(t)
+	ibazel.Run([]string{}, "//vim:test")
+	defer ibazel.Kill()
+	ibazel.ExpectOutput("Started!")
+
+	renameAndWriteNewFile(t, "vim/test.sh", `printf "Started2!"`)
+	ibazel.ExpectOutput("Started2!")
+
+	renameAndWriteNewFile(t, "vim/test.sh", `printf "Started3!"`)
+	ibazel.ExpectOutput("Started3!")
+}
+
+func TestSimpleRunWithModifiedFile_CopyAndTruncWrite(t *testing.T) {
+	e2e.MustMkdir(t, "truncate")
+	e2e.MustWriteFile(t, "truncate/test.sh", `printf "Started!"`)
+	e2e.MustWriteFile(t, "truncate/BUILD", `
+sh_binary(
+	name = "test",
+	srcs = ["test.sh"],
+)
+`)
+
+	ibazel := e2e.NewIBazelTester(t)
+	ibazel.Run([]string{}, "//truncate:test")
+	defer ibazel.Kill()
+	ibazel.ExpectOutput("Started!")
+
+	copyAndTruncWriteFile(t, "truncate/test.sh", `printf "Started2!"`)
+	ibazel.ExpectOutput("Started2!")
+
+	copyAndTruncWriteFile(t, "truncate/test.sh", `printf "Started3!"`)
+	ibazel.ExpectOutput("Started3!")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/bazelbuild/bazel-watcher
+
+require (
+	github.com/bazelbuild/bazel-integration-testing v0.0.0-20191009045751-36e78852bf7e
+	github.com/bazelbuild/rules_go v0.20.2
+	github.com/fsnotify/fsnotify v1.4.7
+	github.com/golang/protobuf v1.3.2
+	github.com/gorilla/websocket v1.4.1 // indirect
+	github.com/jaschaephraim/lrserver v0.0.0-20171129202958-50d19f603f71
+	golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/bazelbuild/bazel-integration-testing v0.0.0-20191009045751-36e78852bf7e h1:E5G5S4QbeWlK9eOv1eLXHEcVcVXZkl0qsMfxkhTTo18=
+github.com/bazelbuild/bazel-integration-testing v0.0.0-20191009045751-36e78852bf7e/go.mod h1:HuUmEhx+3oMTrxL25MynBvOSgOi1/TyjfKbwq7LYbkc=
+github.com/bazelbuild/rules_go v0.20.2 h1:czNuzpSu2qvJ4u0H+5gDCWnzB4y+k2bbH63DOKE0dxM=
+github.com/bazelbuild/rules_go v0.20.2/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
+github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/jaschaephraim/lrserver v0.0.0-20171129202958-50d19f603f71 h1:24NdJ5N6gtrcoeS4JwLMeruKFmg20QdF/5UnX5S/j18=
+github.com/jaschaephraim/lrserver v0.0.0-20171129202958-50d19f603f71/go.mod h1:ozZLfjiLmXytkIUh200wMeuoQJ4ww06wN+KZtFP6j3g=
+golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c h1:S/FtSvpNLtFBgjTqcKsRpsa6aVsI6iztaz1bQd9BJwE=
+golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/ibazel/output_runner/output_runner.go
+++ b/ibazel/output_runner/output_runner.go
@@ -170,7 +170,6 @@ func executeCommand(command string, args []string) {
 	for i, arg := range args {
 		args[i] = strings.TrimSpace(arg)
 	}
-	fmt.Fprintf(os.Stderr, "Executing command: %s\n", command)
 	workspaceFinder := &workspace_finder.MainWorkspaceFinder{}
 	workspacePath, err := workspaceFinder.FindWorkspace()
 	if err != nil {
@@ -181,7 +180,7 @@ func executeCommand(command string, args []string) {
 
 	ctx, _ := context.WithCancel(context.Background())
 	cmd := exec.CommandContext(ctx, command, args...)
-	fmt.Fprintf(os.Stderr, "Executing command: %s %s\n", cmd.Path, strings.Join(cmd.Args, ","))
+	fmt.Fprintf(os.Stderr, "Executing command: %s\n", strings.Join(cmd.Args, " "))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Dir = workspacePath

--- a/ibazel/process_group/BUILD
+++ b/ibazel/process_group/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -24,7 +24,4 @@ go_library(
     ],
     importpath = "github.com/bazelbuild/bazel-watcher/ibazel/process_group",
     visibility = ["//ibazel:__subpackages__"],
-    deps = [
-        "//ibazel/workspace_finder:go_default_library",
-    ],
 )

--- a/release/github/publish.sh
+++ b/release/github/publish.sh
@@ -39,7 +39,7 @@ compile() {
   DESTINATION="${STAGING}/ibazel_${GOOS}_${GOARCH}${EXTENSION}"
   bazel build \
     --config=release \
-    "--experimental_platforms=@io_bazel_rules_go//go/toolchain:${GOOS}_${GOARCH}" \
+    "--platforms=@io_bazel_rules_go//go/toolchain:${GOOS}_${GOARCH}" \
     "//ibazel:ibazel"
   SOURCE="$(bazel info bazel-bin)/ibazel/${GOOS}_${GOARCH}_pure_stripped/ibazel${EXTENSION}"
   cp "${SOURCE}" "${DESTINATION}"

--- a/release/npm/BUILD
+++ b/release/npm/BUILD
@@ -33,7 +33,7 @@ genrule(
 go_library(
     name = "go_default_library",
     srcs = ["generate_package.go"],
-    importpath = "github.com/bazelbuild/bazel-watcher/npm",
+    importpath = "github.com/bazelbuild/bazel-watcher/release/npm",
     visibility = ["//visibility:private"],
 )
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,0 +1,47 @@
+load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+def go_repositories():
+    go_repository(
+        name = "com_github_fsnotify_fsnotify",
+        importpath = "github.com/fsnotify/fsnotify",
+        tag = "v1.4.7",
+    )
+
+    go_repository(
+        name = "com_github_jaschaephraim_lrserver",
+        importpath = "github.com/jaschaephraim/lrserver",
+        tag = "3.0.1",
+    )
+
+    go_repository(
+        name = "com_github_gorilla_websocket",
+        importpath = "github.com/gorilla/websocket",
+        tag = "v1.4.1",
+    )
+
+    go_repository(
+        name = "org_golang_x_sys",
+        commit = "cc5685c2db1239775905f3911f0067c0fa74762f",
+        importpath = "golang.org/x/sys",
+    )
+
+    # NOTE: this must match rules_go version located at
+    # https://github.com/bazelbuild/rules_go/blob/master/go/private/repositories.bzl
+    go_repository(
+        name = "com_github_golang_protobuf",
+        importpath = "github.com/golang/protobuf",
+        tag = "v1.3.2",
+    )
+
+    go_repository(
+        name = "com_github_gorilla_websocket",
+        importpath = "github.com/gorilla/websocket",
+        tag = "v1.4.0",
+    )
+
+    # NOTE: this must match rules_go version above
+    go_repository(
+        name = "com_github_bazelbuild_rules_go",
+        importpath = "github.com/bazelbuild/rules_go",
+        tag = "v0.20.2",
+    )


### PR DESCRIPTION
Also replace bazel_integraion_tests repo with the golang native bazel
testing suite. This doesn't provide coverage for old versions of Bazel,
but it is less of a maintanence burdon since it uses system bazel.

If testing on old versions is deemed high enough value, we can change
the CI config to run this against `current_release` and
`current_release - n` versions of Bazel.