### PR TITLE
Remove tap-bin from Home-brew formula.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ If you run a mac you can install it from [homebrew](https://brew.sh).
 
 ```
 $ brew tap bazelbuild/tap
-$ brew tap-pin bazelbuild/tap
-$ brew install ibazel
+$ brew install bazelbuild/tap/ibazel
 ```
 
 ### NPM


### PR DESCRIPTION
Following the directions for Mac (Homebrew)
$ brew tap bazelbuild/tap
Updating Homebrew...
$ brew tap-pin bazelbuild/tap
Error: Calling brew tap-pin user/tap is disabled! Use fully-scoped user/tap/formula naming instead.
$ brew install bazelbuild/tap/ibazel
==> Installing ibazel from bazelbuild/tap
<snip>