### PR TITLE
Enable run_output by default

### DIFF
--- a/ibazel/output_runner/output_runner.go
+++ b/ibazel/output_runner/output_runner.go
@@ -35,7 +35,7 @@ import (
 
 var runOutput = flag.Bool(
 	"run_output",
-	false,
+	true,
 	"Search for commands in Bazel output that match a regex and execute them, the default path of file should be in the workspace root .bazel_fix_commands.json")
 var runOutputInteractive = flag.Bool(
 	"run_output_interactive",


### PR DESCRIPTION
Since run_output_interactive is enabled, it should be safe to prompt the user
if they want to execute the program that was specified by their repo's
`.bazel_fix_commands.json`