### PR TITLE
Fix output_runner to read from %WORKSPACE

### DIFF
--- a/.bazel_fix_commands.json
+++ b/.bazel_fix_commands.json
@@ -1,0 +1,5 @@
+[{
+    "regex": "^Check that imports in Go sources match importpath attributes in deps.$",
+    "command": "bazel",
+    "args":    ["run", "//:gazelle"]
+}]

--- a/README.md
+++ b/README.md
@@ -76,22 +76,45 @@ stdin.
 
 ## Output Runner
 
-iBazel is capable of producing and running commands from the output of Bazel commands. If iBazel is run with the flag `--run_output` then it will check for a `%WORKSPACE%/.bazel_fix_commands.json` and if present run any commands that match the provided regular expressions.
-For example the commands defined by the following file will match `buildozer` commands found in the output and provide a prompt to run the command.
+iBazel is capable of producing and running commands from the output of Bazel
+commands. If iBazel is run with the flag `--run_output` then it will check for
+a `%WORKSPACE%/.bazel_fix_commands.json` and if present run any commands that
+match the provided regular expressions.  For example the commands defined by
+the following file will match `buildozer` commands found in the output and
+provide a prompt to run the command as well as invoke `bazel run //:gazelle` if
+it detects a missing import for your go code.
+
 ```
-[{
+[
+  {
+    "regex": "^Check that imports in Go sources match importpath attributes in deps.$",
+    "command": "bazel",
+    "args":    ["run", "//:gazelle"]
+  },
+  }
     "regex": "^buildozer '(.*)'\\s+(.*)$",
     "command": "buildozer",
     "args":    ["$1", "$2"],
-}]
+  }
+]
 ```
-Adding the flag `--run_output_interactive=false` will automatically run the command without prompting for confirmation.
-The fields in `.bazel_fix_commands.json` are:
 
-* regex: a regular expression that will be matched against every line of output.
-    * backslash `\` characters will need to be escaped once for the regex to be parsed properly.
+Adding the flag `--run_output_interactive=false` will automatically run the
+command without prompting for confirmation.  The fields in
+`.bazel_fix_commands.json` are:
+
+* regex: a regular expression that will be matched against every line of
+  output.
+    * backslash `\` characters will need to be escaped once for the regex to be
+      parsed properly.
 * command: a command that will be run from the workspace root.
-* args: a list of arguments to provide to the command, with `$1` being the first match group of `regex`, `$2` being the second and so on.
+* args: a list of arguments to provide to the command, with `$1` being the
+  first match group of `regex`, `$2` being the second and so on.
+
+You can disable this feature by adding flag `--run_output=false` or you can
+create a `.bazel_fix_commands.json` that contains an empty json array, `[]`.
+This will additionally disable the notification providing usage instructions on
+the first invocation of iBazel.
 
 ## Profiling
 

--- a/e2e/output_runner/output_runner_test.go
+++ b/e2e/output_runner/output_runner_test.go
@@ -73,6 +73,13 @@ func TestOutputRunner(t *testing.T) {
 	checkSentinel(t, sentinelFile, "ioutil.TempFile creates the file by default. Delete it.")
 	checkNoSentinel(t, sentinelFile, "The sentinal should now be deleted.")
 
+	// First check that it doesn't run if there isn't a `.bazel_fix_commands.json` file.
+	ibazel := e2e.NewIBazelTester(t)
+	ibazel.RunWithBazelFixCommands("//:overwrite")
+
+	// Ensure it prints out the banner.
+	ibazel.ExpectIBazelError("Did you know")
+
 	e2e.MustWriteFile(t, ".bazel_fix_commands.json", fmt.Sprintf(`
 	[{
 		"regex": "^(.*)runacommand(.*)$",
@@ -84,7 +91,6 @@ func TestOutputRunner(t *testing.T) {
 printf "overwrite1"
 `)
 
-	ibazel := e2e.NewIBazelTester(t)
 	ibazel.RunWithBazelFixCommands("//:overwrite")
 
 	ibazel.ExpectOutput("overwrite1")

--- a/ibazel/log/log.go
+++ b/ibazel/log/log.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -14,18 +15,18 @@ var osExit = os.Exit
 var timeNow = time.Now
 
 const (
-	reset color = "\033[0m"
-
-	errorColor color = "\033[31m"
-	fatalColor color = "\033[41m"
-	logColor   color = "\033[96m"
+	resetColor  color = "\033[0m"
+	bannerColor color = "\033[33m"
+	errorColor  color = "\033[31m"
+	fatalColor  color = "\033[41m"
+	logColor    color = "\033[96m"
 )
 
 func log(c color, msg string, args ...interface{}) {
 	fmt.Fprintf(writer, "%siBazel [%s]%s: ",
 		c,
 		timeNow().Local().Format(time.Kitchen),
-		reset)
+		resetColor)
 	fmt.Fprintf(writer, msg, args...)
 	fmt.Fprintf(writer, "\n")
 }
@@ -33,6 +34,22 @@ func log(c color, msg string, args ...interface{}) {
 // NewLine prints a new line to the screen without any preamble.
 func NewLine() {
 	fmt.Fprintf(writer, "\n")
+}
+
+// Print out a banner surrounded by # to draw attention to the eye.
+func Banner(lines ...string) {
+	NewLine()
+	fmt.Fprintf(writer, "%s%s%s", bannerColor, strings.Repeat("#", 80), resetColor)
+	NewLine()
+
+	for _, line := range lines {
+		fmt.Fprintf(writer, "%s#%s %-76s %s#%s", bannerColor, resetColor, line, bannerColor, resetColor)
+		NewLine()
+	}
+
+	fmt.Fprintf(writer, "%s%s%s", bannerColor, strings.Repeat("#", 80), resetColor)
+	NewLine()
+	NewLine()
 }
 
 // Error prints an error to the screen with a preamble.

--- a/ibazel/log/log_test.go
+++ b/ibazel/log/log_test.go
@@ -112,3 +112,23 @@ func TestNonfLoggers(t *testing.T) {
 		})
 	}
 }
+
+func TestBanner(t *testing.T) {
+	buf := &bytes.Buffer{}
+	SetWriter(buf)
+
+	Banner("This is multi", "line output that", "is expected to be printed")
+
+	got := buf.String()
+	want := fmt.Sprintf(`
+%s################################################################################%s
+%s#%s This is multi                                                                %s#%s
+%s#%s line output that                                                             %s#%s
+%s#%s is expected to be printed                                                    %s#%s
+%s################################################################################%s
+
+`, bannerColor, resetColor, bannerColor, resetColor, bannerColor, resetColor, bannerColor, resetColor, bannerColor, resetColor, bannerColor, resetColor, bannerColor, resetColor, bannerColor, resetColor)
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("\nGot:  %q\nWant: %q\nDiff:\n%s", got, want, diff)
+	}
+}

--- a/ibazel/output_runner/output_runner_test.go
+++ b/ibazel/output_runner/output_runner_test.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
+
+	"github.com/bazelbuild/bazel-watcher/ibazel/workspace_finder"
 )
 
 func TestConvertArgs(t *testing.T) {
@@ -56,7 +58,10 @@ func TestConvertArgs(t *testing.T) {
 }
 
 func TestReadConfigs(t *testing.T) {
-	optcmd := readConfigs("output_runner_test.json")
+	i := &OutputRunner{
+		wf: &workspace_finder.FakeWorkspaceFinder{},
+	}
+	optcmd := i.readConfigs("output_runner_test.json")
 
 	for idx, c := range []struct {
 		regex   string
@@ -153,7 +158,7 @@ func TestMatchCleanRegex(t *testing.T) {
 			buf.WriteString(tt.in)
 			cmdLines, _, _ := matchRegex(optcmd, &buf)
 
-			if (!reflect.DeepEqual(cmdLines, tt.out)) {
+			if !reflect.DeepEqual(cmdLines, tt.out) {
 				t.Errorf("Commands not equal!\nGot:  %v\nWant: %v", cmdLines, tt.out)
 			}
 		})


### PR DESCRIPTION
Previously, ibazel would read from `$(pwd)/.bazel_fix_commands.json`
when invoked. This worked when you started iBazel in the root of your
repo, but not when you were in a subdir.

Also added a banner notice so we can broadcast new functionality to
users.