### PR TITLE
Add log messages to explain iBazel time usage

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//third_party/bazel/master/src/main/protobuf/analysis:go_default_library",
         "//third_party/bazel/master/src/main/protobuf/blaze_query:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "//ibazel/log:go_default_library",
     ],
 )
 

--- a/bazel/bazel.go
+++ b/bazel/bazel.go
@@ -30,6 +30,7 @@ import (
 	"github.com/bazelbuild/bazel-watcher/third_party/bazel/master/src/main/protobuf/blaze_query"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/bazelbuild/bazel-watcher/ibazel/log"
 )
 
 var bazelPathFlag = flag.String("bazel_path", "", "Path to the bazel binary to use for actions")
@@ -229,7 +230,7 @@ func (b *bazel) Info() (map[string]string, error) {
 	b.WriteToStderr(false)
 	b.WriteToStdout(false)
 	stdoutBuffer, _ := b.newCommand("info")
-
+	log.Logf("Running 'bazel info'...")
 	err := b.cmd.Run()
 	if err != nil {
 		return nil, err

--- a/bazel/bazel.go
+++ b/bazel/bazel.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/bazelbuild/bazel-watcher/third_party/bazel/master/src/main/protobuf/analysis"
 	"github.com/bazelbuild/bazel-watcher/third_party/bazel/master/src/main/protobuf/blaze_query"
@@ -230,8 +231,18 @@ func (b *bazel) Info() (map[string]string, error) {
 	b.WriteToStderr(false)
 	b.WriteToStdout(false)
 	stdoutBuffer, _ := b.newCommand("info")
-	log.Logf("Running 'bazel info'...")
+
+	// This go function only prints if 'bazel info' takes longer than 5 seconds
+	runFinished := false
+	go func() {
+		time.Sleep(5*time.Second)
+		if !runFinished{
+			log.Logf("Running 'bazel info'...")
+		}
+	}()
+	
 	err := b.cmd.Run()
+	runFinished = true
 	if err != nil {
 		return nil, err
 	}

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -82,7 +82,6 @@ type IBazel struct {
 }
 
 func New() (*IBazel, error) {
-	log.Logf("Initializing iBazel struct i...")
 	i := &IBazel{}
 	err := i.setup()
 	if err != nil {

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -82,6 +82,7 @@ type IBazel struct {
 }
 
 func New() (*IBazel, error) {
+	log.Logf("Initializing iBazel struct i...")
 	i := &IBazel{}
 	err := i.setup()
 	if err != nil {


### PR DESCRIPTION
Sometimes IBazel takes a long time when running `bazel info`. This commit simply adds a couple console logs so developers know what is going on and what is taking time.