### PR TITLE
Add --dynamic_mode flag to overridable list

### DIFF
--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -41,6 +41,7 @@ var overrideableBazelFlags []string = []string{
 	"--curses=no",
 	"-c",
 	"--define=",
+	"--dynamic_mode=",
 	"--features=",
 	"--keep_going",
 	"-k",


### PR DESCRIPTION
Per the manual [1], Bazel supports disabling dynamic linking via the --dynamic_mode flag. Allow overriding that for iblaze builds.

[1] https://docs.bazel.build/versions/master/user-manual.html#flag--dynamic_mode