### PR TITLE
Pass custom build settings on to Bazel

### DIFF
--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -62,6 +62,10 @@ var overrideableBazelFlags []string = []string{
 	"--test_output=",
 	"--test_tag_filters=",
 	"--test_timeout=",
+	// Custom Starlark build settings
+	// https://docs.bazel.build/versions/master/skylark/config.html#using-build-settings-on-the-command-line
+	"--//",
+	"--no//",
 }
 
 var debounceDuration = flag.Duration("debounce", 100*time.Millisecond, "Debounce duration")


### PR DESCRIPTION
This commit adds the prefixes --// and --no// to the list of prefixes
of arguments that should be passed on to Bazel as Starlark build
settings take this form.

See: https://docs.bazel.build/versions/master/skylark/config.html#using-build-settings-on-the-command-line