### PR TITLE
Add support for command execution after successful execution

### DIFF
--- a/e2e/lifecycle_hooks/lifecycle_hooks_test.go
+++ b/e2e/lifecycle_hooks/lifecycle_hooks_test.go
@@ -56,8 +56,11 @@ func TestLifecycleHooks(t *testing.T) {
 	ibazel.RunWithAdditionalArgs("//:test", []string{
 		"-run_command_before=echo hi-before",
 		"-run_command_after=echo hi-after",
+		"-run_command_after_success=echo hi-after-success",
+		"-run_command_after_error=echo hi-after-error",
 	})
 	ibazel.ExpectOutput("hi-before")
 	ibazel.ExpectOutput("hi-after")
+	ibazel.ExpectOutput("hi-after-success")
 	ibazel.Kill()
 }

--- a/e2e/lifecycle_hooks/lifecycle_hooks_test.go
+++ b/e2e/lifecycle_hooks/lifecycle_hooks_test.go
@@ -17,8 +17,15 @@ sh_binary(
   name = "test",
   srcs = ["test.sh"],
 )
+sh_binary(
+  name = "failure",
+  srcs = ["failure.sh"],
+)
 -- test.sh --
 printf "action"
+-- failure.sh --
+printf "Failing"
+exit 1
 `
 
 func TestMain(m *testing.M) {
@@ -52,6 +59,7 @@ func TestMain(m *testing.M) {
 
 func TestLifecycleHooks(t *testing.T) {
 	ibazel := e2e.SetUp(t)
+	defer ibazel.Kill()
 
 	ibazel.RunWithAdditionalArgs("//:test", []string{
 		"-run_command_before=echo hi-before",
@@ -62,5 +70,19 @@ func TestLifecycleHooks(t *testing.T) {
 	ibazel.ExpectOutput("hi-before")
 	ibazel.ExpectOutput("hi-after")
 	ibazel.ExpectOutput("hi-after-success")
-	ibazel.Kill()
+}
+
+func TestLifecycleHooksFailure(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	defer ibazel.Kill()
+
+	ibazel.RunWithAdditionalArgs("//:failure", []string{
+		"-run_command_before=echo hi-before",
+		"-run_command_after=echo hi-after",
+		"-run_command_after_success=echo hi-after-success",
+		"-run_command_after_error=echo hi-after-error",
+	})
+	ibazel.ExpectOutput("hi-before")
+	ibazel.ExpectOutput("hi-after")
+	ibazel.ExpectOutput("hi-after-error")
 }

--- a/e2e/lifecycle_hooks/lifecycle_hooks_test.go
+++ b/e2e/lifecycle_hooks/lifecycle_hooks_test.go
@@ -23,9 +23,6 @@ sh_binary(
 )
 -- test.sh --
 printf "action"
--- failure.sh --
-printf "Failing"
-exit 1
 `
 
 func TestMain(m *testing.M) {
@@ -76,7 +73,7 @@ func TestLifecycleHooksFailure(t *testing.T) {
 	ibazel := e2e.SetUp(t)
 	defer ibazel.Kill()
 
-	ibazel.RunWithAdditionalArgs("//:failure", []string{
+	ibazel.RunUnverifiedWithAdditionalArgs("//:failure", []string{
 		"-run_command_before=echo hi-before",
 		"-run_command_after=echo hi-after",
 		"-run_command_after_success=echo hi-after-success",

--- a/ibazel/lifecycle_hooks/lifecycle_hooks.go
+++ b/ibazel/lifecycle_hooks/lifecycle_hooks.go
@@ -30,6 +30,7 @@ var (
 	runCommandBefore       = flag.String("run_command_before", "", "A command to run before each execution")
 	runCommandAfter        = flag.String("run_command_after", "", "A command to run after each execution")
 	runCommandAfterSuccess = flag.String("run_command_after_success", "", "A command to run after each successful execution")
+	runCommandAfterError   = flag.String("run_command_after_error", "", "A command to run after each failed execution")
 )
 
 type LifecycleHooks struct {
@@ -58,6 +59,8 @@ func (l *LifecycleHooks) AfterCommand(targets []string, command string, success 
 	l.parseAndExecuteCommand(*runCommandAfter)
 	if success {
 		l.parseAndExecuteCommand(*runCommandAfterSuccess)
+	} else {
+		l.parseAndExecuteCommand(*runCommandAfterError)
 	}
 }
 

--- a/ibazel/lifecycle_hooks/lifecycle_hooks.go
+++ b/ibazel/lifecycle_hooks/lifecycle_hooks.go
@@ -27,8 +27,9 @@ import (
 )
 
 var (
-	runCommandBefore = flag.String("run_command_before", "", "A command to run before each execution")
-	runCommandAfter  = flag.String("run_command_after", "", "A command to run after each execution")
+	runCommandBefore       = flag.String("run_command_before", "", "A command to run before each execution")
+	runCommandAfter        = flag.String("run_command_after", "", "A command to run after each execution")
+	runCommandAfterSuccess = flag.String("run_command_after_success", "", "A command to run after each successful execution")
 )
 
 type LifecycleHooks struct {
@@ -55,6 +56,9 @@ func (l *LifecycleHooks) BeforeCommand(targets []string, command string) {
 
 func (l *LifecycleHooks) AfterCommand(targets []string, command string, success bool, output *bytes.Buffer) {
 	l.parseAndExecuteCommand(*runCommandAfter)
+	if success {
+		l.parseAndExecuteCommand(*runCommandAfterSuccess)
+	}
 }
 
 func (l *LifecycleHooks) parseAndExecuteCommand(commandToRun string) {


### PR DESCRIPTION
The "-run_command_after_success" flag is nearly identical to
the "-run_command_after" flag, but instead of operating
unconditionally, it only executes if the previous command
was successful.

This can provide value for exeucting a command which operates
on the output of a bazel build, and which should only
execute if there is new output to act upon.