### PR TITLE
Simplify setting of execute bit

### DIFF
--- a/e2e/common.go
+++ b/e2e/common.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
@@ -77,8 +78,10 @@ func SetExecuteBit(t *testing.T) {
 			return err
 		}
 
-		if err := os.Chmod(path, 0777); err != nil {
-			t.Fatalf("Error os.Chmod(%q, 0777): %v", path, err)
+		if strings.HasSuffix(path, ".sh") {
+			if err := os.Chmod(path, 0777); err != nil {
+				t.Fatalf("Error os.Chmod(%q, 0777): %v", path, err)
+			}
 		}
 
 		return nil

--- a/e2e/lifecycle_hooks/lifecycle_hooks_test.go
+++ b/e2e/lifecycle_hooks/lifecycle_hooks_test.go
@@ -1,10 +1,6 @@
 package lifecycle_hooks
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/bazelbuild/bazel-watcher/e2e"
@@ -28,29 +24,6 @@ printf "action"
 func TestMain(m *testing.M) {
 	bazel_testing.TestMain(m, bazel_testing.Args{
 		Main: mainFiles,
-		SetUp: func() error {
-			wd, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-
-			if err := filepath.Walk(wd, func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-
-				if strings.HasSuffix(path, ".sh") {
-					if err := os.Chmod(path, 0777); err != nil {
-						return fmt.Errorf("Error os.Chmod(%q, 0777): %v", path, err)
-					}
-				}
-				return nil
-			}); err != nil {
-				fmt.Printf("Error walking dir: %v\n", err)
-				return err
-			}
-			return nil
-		},
 	})
 }
 

--- a/e2e/local_repository/local_repository_test.go
+++ b/e2e/local_repository/local_repository_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/bazelbuild/bazel-watcher/e2e"
@@ -80,26 +79,6 @@ func TestMain(m *testing.M) {
 						log.Fatalf("Failed to write file %q: %v", file, err)
 					}
 				}
-			}
-			wd, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-
-			if err := filepath.Walk(wd, func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-
-				if strings.HasSuffix(path, ".sh") {
-					if err := os.Chmod(path, 0777); err != nil {
-						return fmt.Errorf("Error os.Chmod(%q, 0777): %v", path, err)
-					}
-				}
-				return nil
-			}); err != nil {
-				fmt.Printf("Error walking dir: %v\n", err)
-				return err
 			}
 			return nil
 		},

--- a/e2e/output_runner/output_runner_test.go
+++ b/e2e/output_runner/output_runner_test.go
@@ -78,8 +78,6 @@ func checkSentinel(t *testing.T, sentinelFile *os.File, msg string) {
 }
 
 func TestOutputRunner(t *testing.T) {
-	e2e.SetExecuteBit(t)
-
 	sentinelFile, err := ioutil.TempFile("", "fixCommandSentinel")
 	if err != nil {
 		t.Errorf("ioutil.TempFile(\"\", \"fixCommandSentinel\": %v", err)
@@ -91,7 +89,7 @@ func TestOutputRunner(t *testing.T) {
 	checkNoSentinel(t, sentinelFile, "The sentinal should now be deleted.")
 
 	// First check that it doesn't run if there isn't a `.bazel_fix_commands.json` file.
-	ibazel := e2e.NewIBazelTester(t)
+	ibazel := e2e.SetUp(t)
 	ibazel.RunWithBazelFixCommands("//single:overwrite")
 
 	// Ensure it prints out the banner.
@@ -117,7 +115,7 @@ printf "overwrite1"
 
 	// Invoke the test a 2nd time to ensure it works over multiple separate
 	// invocations of ibazel.
-	ibazel = e2e.NewIBazelTester(t)
+	ibazel = e2e.SetUp(t)
 	ibazel.RunWithBazelFixCommands("//single:overwrite")
 	ibazel.ExpectOutput("overwrite1")
 	checkSentinel(t, sentinelFile, "The second run should create a sentinel.")
@@ -140,8 +138,6 @@ def fix_deps():
 }
 
 func TestOutputRunnerUniqueCommandsOnly(t *testing.T) {
-	e2e.SetExecuteBit(t)
-
 	e2e.MustWriteFile(t, ".bazel_fix_commands.json", `
        [{
                "regex": "^.*runcommand (.*)$",
@@ -149,8 +145,7 @@ func TestOutputRunnerUniqueCommandsOnly(t *testing.T) {
                "args": ["$1"]
        }]`)
 
-
-	ibazel := e2e.NewIBazelTester(t)
+	ibazel := e2e.SetUp(t)
 	ibazel.RunWithBazelFixCommands("//multiple:test")
 	defer ibazel.Kill()
 

--- a/e2e/simple/simple_test.go
+++ b/e2e/simple/simple_test.go
@@ -2,12 +2,9 @@ package simple
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 	"syscall"
 	"testing"
 
@@ -62,29 +59,6 @@ printf "Hello subdir!"
 func TestMain(m *testing.M) {
 	bazel_testing.TestMain(m, bazel_testing.Args{
 		Main: mainFiles,
-		SetUp: func() error {
-			wd, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-
-			if err := filepath.Walk(wd, func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-
-				if strings.HasSuffix(path, ".sh") {
-					if err := os.Chmod(path, 0777); err != nil {
-						return fmt.Errorf("Error os.Chmod(%q, 0777): %v", path, err)
-					}
-				}
-				return nil
-			}); err != nil {
-				fmt.Printf("Error walking dir: %v\n", err)
-				return err
-			}
-			return nil
-		},
 	})
 }
 

--- a/e2e/termination/termination_test.go
+++ b/e2e/termination/termination_test.go
@@ -1,11 +1,7 @@
 package termination
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
 	"runtime"
-	"strings"
 	"syscall"
 	"testing"
 
@@ -37,29 +33,6 @@ sh_binary(
 func TestMain(m *testing.M) {
 	bazel_testing.TestMain(m, bazel_testing.Args{
 		Main: mainFiles,
-		SetUp: func() error {
-			wd, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-
-			if err := filepath.Walk(wd, func(path string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-
-				if strings.HasSuffix(path, ".sh") {
-					if err := os.Chmod(path, 0777); err != nil {
-						return fmt.Errorf("Error os.Chmod(%q, 0777): %v", path, err)
-					}
-				}
-				return nil
-			}); err != nil {
-				fmt.Printf("Error walking dir: %v\n", err)
-				return err
-			}
-			return nil
-		},
 	})
 }
 


### PR DESCRIPTION
Instead of providing multiple avenues for making shell scripts executable, converge on "e2e.SetUp" internally invoking directory walk + chmodding