### PR TITLE
Add --compile_one_dependency as overrideable flag

### DIFF
--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -37,6 +37,7 @@ var overrideableBazelFlags []string = []string{
 	"--build_tag_filters=",
 	"--build_tests_only",
 	"--compilation_mode",
+	"--compile_one_dependency",
 	"--config=",
 	"--copt=",
 	"--curses=no",


### PR DESCRIPTION
Documented here: https://docs.bazel.build/versions/3.7.0/user-manual.html#flag--compile_one_dependency