### PR TITLE
bazel: simplify done channel rendezvous

### DIFF
--- a/bazel/bazel.go
+++ b/bazel/bazel.go
@@ -233,10 +233,8 @@ func (b *bazel) Info() (map[string]string, error) {
 	stdoutBuffer, _ := b.newCommand("info")
 
 	// This gofunction only prints if 'bazel info' takes longer than 8 seconds
-	doneCh := make(chan struct{}, 1)
-	defer func() {
-		doneCh <- struct{}{}
-	}()
+	doneCh := make(chan struct{})
+	defer close(doneCh)
 	go func() {
 		select {
 			case <- doneCh:


### PR DESCRIPTION
Simplify the channel rendezvous to instead of using a buffered channel
with an unergonomical `ch <- struct{}{}` use a `defer close(ch)`
semantic.  This change is within its scope of usage isomorphic.