### PR TITLE
add flags to set host, port and protocol for the ibazel server

### DIFF
--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/bazelbuild/bazel-watcher/ibazel/log"
+	"github.com/bazelbuild/bazel-watcher/ibazel/live_reload"
 )
 
 var Version = "Development"
@@ -151,7 +152,16 @@ func parseArgs(in []string) (targets, startupArgs, bazelArgs, args []string) {
 // main entrypoint for IBazel.
 func main() {
 	flag.Usage = usage
+	hostPtr := flag.String("host", "localhost", "host value for ibazel server to contact back to")
+	portPtr := flag.Int("port", 35729, "port value for ibazel server to contact back to, if all values are left as default it will search for a port until one is found")
+	protocolPtr := flag.String("protocol", "http", "protocol ibazel with use to make the call")
 	flag.Parse()
+
+	var liveReloadOpts live_reload.LiveReload
+	liveReloadOpts.Host = *hostPtr
+	liveReloadOpts.Port = uint16(*portPtr)
+	liveReloadOpts.Protocol = *protocolPtr
+	live_reload.SetLiveReload(liveReloadOpts)
 
 	if *logToFile != "-" {
 		var err error


### PR DESCRIPTION
To set the flags use: 
--host=
--port=
--protocol=
These flags are not required though.

ex: ibazel --host=test.com --port=8080 --protocol=https run //:target

This does not change the default behaviour if all the flags are left unset ibazel will still try to find an open port on localhost like it did before. Keeping it easy to use out of the box.
This means there aren't any breaking changes to previous workflows or users which seemed to be a concern here: https://github.com/bazelbuild/bazel-watcher/issues/403

Hopefully adding these flags doesn't greatly increase the maintenance overhead while allowing for more advanced use cases.