### PR TITLE
chore(NA): adds --show_result into the iBazel proxied flags list

### DIFF
--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -57,6 +57,7 @@ var overrideableBazelFlags []string = []string{
 	"--repo_env",
 	"--runs_per_test=",
 	"--run_under=",
+	"--show_result=",
 	"--stamp",
 	"--strategy=",
 	"--test_arg=",


### PR DESCRIPTION
I've just found `--show_result` as an useful flag to be proxied into bazel and that should be added into that list