### PR TITLE
chore(NA): avoid experimental logger warning if IBAZEL_USE_LEGACY_WATCHER=0

### DIFF
--- a/ibazel/fswatcher/factory_darwin.go
+++ b/ibazel/fswatcher/factory_darwin.go
@@ -33,8 +33,13 @@ func NewWatcher() (common.Watcher, error) {
 	if ok && flag != "0" {
 		return fsnotify.NewWatcher()
 	}
-	experimentalWatcherLog.Do(func() {
+
+	// Avoid logging if IBAZEL_USE_LEGACY_WATCHER=0
+	if !ok {
+		experimentalWatcherLog.Do(func() {
 		log.Log("You are using an experimental filesystem watcher. If you would like to disable that, please set the environment variable\n\tIBAZEL_USE_LEGACY_WATCHER=1")
 	})
+	}
+
 	return fsevents.NewWatcher()
 }


### PR DESCRIPTION
That PR introduces a simple change so we can avoid to log about the experimental logging feature in use if we choose to set the env var explicitly to `IBAZEL_USE_LEGACY_WATCHER=0`.

