### PR TITLE
Update description

### DIFF
--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -79,7 +79,7 @@ func usage() {
 	fmt.Fprintf(os.Stderr, `iBazel - Version %s
 
 A file watcher for Bazel. Whenever a source file used in a specified
-target, run, build, or test the specified targets.
+target changes, run, build, or test the specified targets.
 
 Usage:
 


### PR DESCRIPTION
Add missing word in the description which is printed when `--help` is run.