### PR TITLE
Support concatenating static text with substitutions in output runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ it detects a missing import for your go code.
     "regex": "^buildozer '(.*)'\\s+(.*)$",
     "command": "buildozer",
     "args": [ "$1", "$2" ]
+  },
+  {
+    "regex": "^(\\S+)/[\\w-]+\\.proto:\\d+:\\d+: Import \"\\S+\" was not found or had errors\\.$",
+    "command": "bazel",
+    "args": [ "run", "//:gazelle", "--", "proto/$1" ]
   }
 ]
 ```
@@ -101,13 +106,14 @@ Adding the flag `--run_output_interactive=false` will automatically run the
 command without prompting for confirmation.  The fields in
 `.bazel_fix_commands.json` are:
 
-* regex: a regular expression that will be matched against every line of
+* `regex`: a regular expression that will be matched against every line of
   output.
     * backslash `\` characters will need to be escaped once for the regex to be
       parsed properly.
-* command: a command that will be run from the workspace root.
-* args: a list of arguments to provide to the command, with `$1` being the
-  first match group of `regex`, `$2` being the second and so on.
+* `command`: a command that will be run from the workspace root.
+* `args`: a list of arguments to provide to the command, substituting `$1`
+  with the first match group of `regex`, `$2` with the second, etc., and `$0`
+  for the entire match.
 
 You can disable this feature by adding flag `--run_output=false` or you can
 create a `.bazel_fix_commands.json` that contains an empty json array, `[]`.

--- a/ibazel/output_runner/output_runner_test.go
+++ b/ibazel/output_runner/output_runner_test.go
@@ -48,6 +48,10 @@ func TestConvertArgs(t *testing.T) {
 		{[]string{"$2", "$3", "$4"}, []string{"my_arg1", "my_arg2", "my_arg3"}},
 		{[]string{"$2", "dont_change_arg"}, []string{"my_arg1", "dont_change_arg"}},
 		{[]string{"keep_arg", "$3"}, []string{"keep_arg", "my_arg2"}},
+		{[]string{"$2,$3"}, []string{"my_arg1,my_arg2"}},
+		{[]string{"src/$2:1"}, []string{"src/my_arg1:1"}},
+		{[]string{"literal$$char"}, []string{"literal$char"}},
+		{[]string{"$99"}, []string{"$99"}},
 	} {
 		new_cmd := convertArgs(matches, c.cmd)
 		if !reflect.DeepEqual(c.truth, new_cmd) {


### PR DESCRIPTION
Our use case: sometimes we want to run gazelle on a directory whose full path can't be extracted directly from the output.