### PR TITLE
Stream output when testing a single target

### DIFF
--- a/cmd/ibazel/main.go
+++ b/cmd/ibazel/main.go
@@ -162,7 +162,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		log.SetWriter(logFile)
+		log.SetLogger(log.NewWriterLogger(logFile))
 	}
 
 	if len(flag.Args()) < 2 {

--- a/internal/bazel/bazel.go
+++ b/internal/bazel/bazel.go
@@ -292,22 +292,21 @@ func (b *bazel) Query(args ...string) (*blaze_query.QueryResult, error) {
 	blazeArgs := append([]string(nil), "--output=proto", "--order_output=no", "--color=no")
 	blazeArgs = append(blazeArgs, args...)
 
-	b.WriteToStderr(true)
+	b.WriteToStderr(false)
 	b.WriteToStdout(false)
-	stdoutBuffer, _ := b.newCommand("query", blazeArgs...)
+	stdoutBuffer, stderrBuff := b.newCommand("query", blazeArgs...)
 
 	err := b.cmd.Run()
-
 	if err != nil {
 		return nil, err
 	}
-	return b.processQuery(stdoutBuffer.Bytes())
+	return b.processQuery(stdoutBuffer.Bytes(), stderrBuff.Bytes())
 }
 
-func (b *bazel) processQuery(out []byte) (*blaze_query.QueryResult, error) {
+func (b *bazel) processQuery(stdout []byte, stderr []byte) (*blaze_query.QueryResult, error) {
 	var qr blaze_query.QueryResult
-	if err := proto.Unmarshal(out, &qr); err != nil {
-		fmt.Fprintf(os.Stderr, "Could not read blaze query response. Error: %s\nOutput: %s\n", err, out)
+	if err := proto.Unmarshal(stdout, &qr); err != nil {
+		log.Errorf("Could not read blaze query response. Error: %s\nOutput: %s\nStderr: %s\n", err, stdout, string(stderr))
 		return nil, err
 	}
 

--- a/internal/bazel/bazel.go
+++ b/internal/bazel/bazel.go
@@ -128,6 +128,7 @@ func findBazel() string {
 }
 
 type Bazel interface {
+	Args() []string
 	SetArguments([]string)
 	SetStartupArgs([]string)
 	WriteToStderr(v bool)
@@ -157,6 +158,10 @@ type bazel struct {
 
 func New() Bazel {
 	return &bazel{}
+}
+
+func (b *bazel) Args() []string {
+	return b.args
 }
 
 func (b *bazel) SetArguments(args []string) {

--- a/internal/bazel/testing/BUILD
+++ b/internal/bazel/testing/BUILD
@@ -22,5 +22,6 @@ go_library(
     deps = [
         "//third_party/bazel/master/src/main/protobuf/analysis",
         "//third_party/bazel/master/src/main/protobuf/blaze_query",
+        "@com_github_google_go_cmp//cmp",
     ],
 )

--- a/internal/bazel/testing/mock.go
+++ b/internal/bazel/testing/mock.go
@@ -35,6 +35,10 @@ type MockBazel struct {
 	waitError  error
 }
 
+func (b *MockBazel) Args() []string {
+	return b.args
+}
+
 func (b *MockBazel) SetArguments(args []string) {
 	b.args = args
 }

--- a/internal/e2e/stream/BUILD
+++ b/internal/e2e/stream/BUILD
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "stream_test",
+    srcs = ["stream_test.go"],
+    deps = [
+        "//internal/e2e",
+        "@io_bazel_rules_go//go/tools/bazel_testing:go_default_library",
+    ],
+)

--- a/internal/e2e/stream/stream_test.go
+++ b/internal/e2e/stream/stream_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 const mainFiles = `
--- BUILD.bazel --
+-- single/BUILD.bazel --
 # Create an sh_test that passes and prints some output. Confirm that the
 # results were streamed.
 sh_test(
   name = "stream",
   srcs = ["stream.sh"],
 )
--- stream.sh --
+-- single/stream.sh --
 printf "test output"
 exit 0
 `
@@ -31,16 +31,16 @@ func TestSimpleTest(t *testing.T) {
 	// When iBazel can detect that you're testing a single target, it will run
 	// the test with "--test_output=streamed" so that you can see the results
 	// live.
-	e2e.MustWriteFile(t, "stream.sh", `printf "TestSimpleTest1"`)
+	e2e.MustWriteFile(t, "single/stream.sh", `printf "TestSimpleTest1"`)
 
 	ibazel := e2e.SetUp(t)
-	ibazel.Test([]string{}, "//:stream")
+	ibazel.Test([]string{}, "//single:stream")
 	defer ibazel.Kill()
 
 	ibazel.ExpectOutput("TestSimpleTest1")
 
 	// Now when the file is updated it should still be run in streaming mode.
-	e2e.MustWriteFile(t, "stream.sh", `printf "TestSimpleTest2"`)
+	e2e.MustWriteFile(t, "single/stream.sh", `printf "TestSimpleTest2"`)
 	ibazel.ExpectOutput("TestSimpleTest2")
 }
 
@@ -49,9 +49,9 @@ func TestSingleQueryTarget(t *testing.T) {
 	// the test with "--test_output=streamed" so that you can see the results
 	// live.
 
-	e2e.MustWriteFile(t, "stream.sh", `printf "TestSingleQueryTarget"`)
+	e2e.MustWriteFile(t, "single/stream.sh", `printf "TestSingleQueryTarget"`)
 	ibazel := e2e.SetUp(t)
-	ibazel.Test([]string{}, "//:all")
+	ibazel.Test([]string{}, "//single:all")
 	defer ibazel.Kill()
 
 	ibazel.ExpectOutput("TestSingleQueryTarget")
@@ -62,9 +62,9 @@ func TestMultipleQueryTarget(t *testing.T) {
 	// the test with "--test_output=streamed" so that you can see the results
 	// live.
 
-	e2e.MustWriteFile(t, "stream.sh", `printf "TestMultipleQueryTarget"`)
+	e2e.MustWriteFile(t, "single/stream.sh", `printf "TestMultipleQueryTarget"`)
 	ibazel := e2e.SetUp(t)
-	ibazel.Test([]string{}, "//:all", "//...")
+	ibazel.Test([]string{}, "//single:all", "//...")
 	defer ibazel.Kill()
 
 	ibazel.ExpectOutput("TestMultipleQueryTarget")
@@ -75,9 +75,9 @@ func TestExplicitlySetOutputToSummary(t *testing.T) {
 	// the test with "--test_output=streamed" so that you can see the results
 	// live.
 
-	e2e.MustWriteFile(t, "stream.sh", `printf "TestExplicitlySetOutputToSummary"`)
+	e2e.MustWriteFile(t, "single/stream.sh", `printf "TestExplicitlySetOutputToSummary"`)
 	ibazel := e2e.SetUp(t)
-	ibazel.Test([]string{"--test_output=summary"}, "//:all", "//...")
+	ibazel.Test([]string{"--test_output=summary"}, "//single:all", "//...")
 	defer ibazel.Kill()
 
 	// Wait for it to pass.

--- a/internal/ibazel/BUILD
+++ b/internal/ibazel/BUILD
@@ -51,6 +51,7 @@ go_test(
         "//internal/ibazel/fswatcher/common",
         "//internal/ibazel/log",
         "//internal/ibazel/workspace",
+        "//third_party/bazel/master/src/main/protobuf/analysis",
         "//third_party/bazel/master/src/main/protobuf/blaze_query",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],

--- a/internal/ibazel/command/BUILD
+++ b/internal/ibazel/command/BUILD
@@ -43,6 +43,7 @@ go_test(
     deps = [
         "//internal/bazel",
         "//internal/bazel/testing",
+        "//internal/ibazel/log",
         "//internal/ibazel/process_group",
     ],
 )

--- a/internal/ibazel/command/command_test.go
+++ b/internal/ibazel/command/command_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/bazel-watcher/internal/bazel"
+	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/process_group"
 )
 
@@ -38,6 +39,8 @@ func assertKilled(t *testing.T, cmd *exec.Cmd) {
 }
 
 func TestSubprocessRunning(t *testing.T) {
+	log.SetLogger(t)
+
 	execCommand = func(name string, args ...string) process_group.ProcessGroup {
 		return oldExecCommand("ls") // Every system has ls.
 	}

--- a/internal/ibazel/command/default_command_test.go
+++ b/internal/ibazel/command/default_command_test.go
@@ -20,10 +20,13 @@ import (
 	"testing"
 
 	mock_bazel "github.com/bazelbuild/bazel-watcher/internal/bazel/testing"
+	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/process_group"
 )
 
 func TestDefaultCommand(t *testing.T) {
+	log.SetLogger(t)
+
 	var toKill process_group.ProcessGroup
 
 	if runtime.GOOS == "windows" {
@@ -65,6 +68,8 @@ func TestDefaultCommand(t *testing.T) {
 }
 
 func TestDefaultCommand_Start(t *testing.T) {
+	log.SetLogger(t)
+
 	// Set up mock execCommand and prep it to be returned
 	execCommand = func(name string, args ...string) process_group.ProcessGroup {
 		if runtime.GOOS == "windows" {

--- a/internal/ibazel/command/notify_command_test.go
+++ b/internal/ibazel/command/notify_command_test.go
@@ -20,10 +20,13 @@ import (
 
 	"github.com/bazelbuild/bazel-watcher/internal/bazel"
 	mock_bazel "github.com/bazelbuild/bazel-watcher/internal/bazel/testing"
+	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/process_group"
 )
 
 func TestNotifyCommand(t *testing.T) {
+	log.SetLogger(t)
+
 	pg := process_group.Command("cat")
 
 	c := &notifyCommand{
@@ -56,25 +59,37 @@ func TestNotifyCommand(t *testing.T) {
 	c.NotifyOfChanges()
 
 	b.AssertActions(t, [][]string{
-		{"WriteToStderr"},
-		{"WriteToStdout"},
+		{"SetStartupArgs"},
+		{"SetArguments"},
+		{"WriteToStderr", "true"},
+		{"WriteToStdout", "true"},
 		{"Build", "//path/to:target"},
-		{"WriteToStderr"},
-		{"WriteToStdout"},
+		{"SetStartupArgs"},
+		{"SetArguments"},
+		{"WriteToStderr", "true"},
+		{"WriteToStdout", "true"},
 		{"Run", "--script_path=.*", "//path/to:target"},
-		{"WriteToStderr"},
-		{"WriteToStdout"},
+		{"SetStartupArgs"},
+		{"SetArguments"},
+		{"WriteToStderr", "true"},
+		{"WriteToStdout", "true"},
 		{"Build", "//path/to:target"},
-		{"WriteToStderr"},
-		{"WriteToStdout"},
+		{"SetStartupArgs"},
+		{"SetArguments"},
+		{"WriteToStderr", "true"},
+		{"WriteToStdout", "true"},
 		{"Build", "//path/to:target"},
-		{"WriteToStderr"},
-		{"WriteToStdout"},
+		{"SetStartupArgs"},
+		{"SetArguments"},
+		{"WriteToStderr", "true"},
+		{"WriteToStdout", "true"},
 		{"Run", "--script_path=.*", "//path/to:target"},
 	})
 }
 
 func TestNotifyCommand_Restart(t *testing.T) {
+	log.SetLogger(t)
+
 	var pg process_group.ProcessGroup
 
 	pg = process_group.Command("ls")

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -375,7 +375,7 @@ func (i *IBazel) test(targets ...string) (*bytes.Buffer, error) {
 		}
 		if setStream {
 			log.Log("Found a single target test. Streaming results. You can override this by explicitly passing --test_output=summary")
-			b.SetArguments([]string{"--test_output=streamed"})
+			b.SetArguments(append([]string{"--test_output=streamed"}, b.Args()...))
 		}
 	}
 

--- a/internal/ibazel/log/log_test.go
+++ b/internal/ibazel/log/log_test.go
@@ -89,7 +89,7 @@ func TestNonfLoggers(t *testing.T) {
 			}
 
 			buf := &bytes.Buffer{}
-			SetWriter(buf)
+			SetLogger(&writerLogger{buf})
 
 			switch f := test.method.(type) {
 			case func(string):
@@ -115,7 +115,7 @@ func TestNonfLoggers(t *testing.T) {
 
 func TestBanner(t *testing.T) {
 	buf := &bytes.Buffer{}
-	SetWriter(buf)
+	SetLogger(&writerLogger{buf})
 
 	Banner("This is multi", "line output that", "is expected to be printed")
 

--- a/internal/ibazel/output_runner/BUILD
+++ b/internal/ibazel/output_runner/BUILD
@@ -32,5 +32,8 @@ go_test(
     data = ["output_runner_test.json"],
     embed = [":output_runner"],
     importpath = "github.com/bazelbuild/bazel-watcher/ibazel",
-    deps = ["//internal/ibazel/workspace"],
+    deps = [
+        "//internal/ibazel/log",
+        "//internal/ibazel/workspace",
+    ],
 )

--- a/internal/ibazel/output_runner/output_runner_test.go
+++ b/internal/ibazel/output_runner/output_runner_test.go
@@ -19,10 +19,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/workspace"
 )
 
 func TestConvertArgs(t *testing.T) {
+	log.SetTesting(t)
+
 	matches := []string{"my_command my_arg1 my_arg2 my_arg3", "my_command", "my_arg1", "my_arg2", "my_arg3"}
 	// Command parsing tests
 	for _, c := range []struct {
@@ -62,6 +65,8 @@ func TestConvertArgs(t *testing.T) {
 }
 
 func TestReadConfigs(t *testing.T) {
+	log.SetTesting(t)
+
 	i := &OutputRunner{
 		w: &workspace.FakeWorkspace{},
 	}
@@ -92,6 +97,8 @@ func TestReadConfigs(t *testing.T) {
 }
 
 func TestMatchRegex(t *testing.T) {
+	log.SetTesting(t)
+
 	buf := bytes.Buffer{}
 	buf.WriteString("buildozer 'add deps test_dep1' //target1:target1\n")
 	buf.WriteString("buildozer 'add deps test_dep2' //target2:target2\n")
@@ -159,6 +166,8 @@ var cleanerTests = []struct {
 }
 
 func TestMatchCleanRegex(t *testing.T) {
+	log.SetTesting(t)
+
 	optcmd := []Optcmd{
 		{Regex: "^(buildozer) '(.*)'\\s+(.*)$", Command: "$1", Args: []string{"$2", "$3"}},
 	}
@@ -174,5 +183,4 @@ func TestMatchCleanRegex(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/internal/ibazel/workspace/BUILD
+++ b/internal/ibazel/workspace/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "workspace",
@@ -20,4 +20,14 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-watcher/internal/ibazel/workspace",
     visibility = ["//:__subpackages__"],
     deps = ["//internal/ibazel/log"],
+)
+
+go_test(
+    name = "workspace_test",
+    srcs = ["workspace_test.go"],
+    embed = [":workspace"],
+    deps = [
+        "//internal/ibazel/log",
+        "@com_github_google_go_cmp//cmp",
+    ],
 )

--- a/internal/ibazel/workspace/workspace.go
+++ b/internal/ibazel/workspace/workspace.go
@@ -47,11 +47,16 @@ func (m *MainWorkspace) FindWorkspace() (string, error) {
 		}
 
 		// Check if we're at the workspace path
-		if _, err := os.Stat(filepath.Join(path, "WORKSPACE")); !os.IsNotExist(err) {
-			return path, nil
+		if s, err := os.Stat(filepath.Join(path, "WORKSPACE")); err == nil {
+			if !s.IsDir() && s.Name() == "WORKSPACE" {
+				// In macOS directories called "workspace" will match because the file
+				// system isn't case sensitive.
+				return path, nil
+			}
 		}
 
-		if _, err := os.Stat(filepath.Join(path, "WORKSPACE.bazel")); !os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(path, "WORKSPACE.bazel")); err == nil {
+			log.Fatalf("WORKSPACE.bazel")
 			return path, nil
 		}
 

--- a/internal/ibazel/workspace/workspace_test.go
+++ b/internal/ibazel/workspace/workspace_test.go
@@ -1,0 +1,136 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAppleCaseInsensitivity(t *testing.T) {
+	log.SetTesting(t)
+
+	tests := map[string]struct {
+		// startingWD to start the test in when evaluating FindWorkspace
+		startingWD string
+		// wantPath should be the relative path the workspace is found in.
+		wantPath string
+		// dirs are recursively created to allow both dirs and files to exist.
+		dirs []string
+		// path to create the workspace in. Must be created by dirs.
+		workspacePath string
+		// files are touched and left empty.
+		files []string
+		err   bool
+	}{
+		"simple": {
+			startingWD:    "",
+			wantPath:      "",
+			dirs:          []string{},
+			workspacePath: "/WORKSPACE",
+			files:         []string{},
+			err:           false,
+		},
+		"no workspace": {
+			startingWD: "c/d",
+			wantPath:   "",
+			dirs: []string{
+				"a/b",
+				"c/d",
+			},
+			workspacePath: "/a/WORKSPACE",
+			files:         []string{},
+			err:           true,
+		},
+		"nested workspace": {
+			startingWD: "a/workspace",
+			wantPath:   "",
+			dirs: []string{
+				"a/workspace",
+			},
+			workspacePath: "/WORKSPACE",
+			files:         []string{},
+			err:           false,
+		},
+		"nested workspace in directory containing nested workspace": {
+			startingWD: "a",
+			wantPath:   "",
+			dirs: []string{
+				"a/workspace",
+			},
+			workspacePath: "/WORKSPACE",
+			files:         []string{},
+			err:           false,
+		},
+	}
+
+	startDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("pwd: %v", err)
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			defer os.Chdir(startDir)
+			base := t.TempDir()
+
+			// t.TempDir may return a path that isn't the place you end up when you
+			// cd to it, so cd there and get that value.
+			if err := os.Chdir(base); err != nil {
+				t.Fatalf("cd %q", base)
+			}
+			var err error
+			if base, err = os.Getwd(); err != nil {
+				t.Fatalf("pwd: %v", err)
+			}
+
+			for _, dir := range test.dirs {
+				path := filepath.Join(base, dir)
+				if err := os.MkdirAll(path, 0755); err != nil {
+					t.Fatalf("MkdirAll(%q): %v", path, err)
+				}
+			}
+
+			baseWorkspace := filepath.Join(base, test.workspacePath)
+			if err := os.WriteFile(baseWorkspace, []byte{}, 0644); err != nil {
+				t.Fatalf("os.WriteFile(%q): %v", baseWorkspace, err)
+			}
+
+			for _, file := range test.files {
+				path := filepath.Join(base, file)
+				dir := filepath.Dir(path)
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					t.Fatalf("MkdirAll(%q): %v", dir, err)
+				}
+				if err := os.WriteFile(path, []byte{}, 0644); err != nil {
+					t.Fatalf("os.WriteFile(%q): %v", path, err)
+				}
+			}
+
+			startingWD := filepath.Join(base, test.startingWD)
+			if err := os.Chdir(startingWD); err != nil {
+				t.Fatalf("cd %q", startingWD)
+			}
+
+			wf := &MainWorkspace{}
+			got, err := wf.FindWorkspace()
+			if test.err {
+				if err == nil {
+					t.Errorf("FindWorkspace() got nil want an error")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("FindWorkspace(): %v", err)
+				}
+
+				got = strings.TrimPrefix(got, base)
+				if diff := cmp.Diff(got, test.wantPath); diff != "" {
+					t.Errorf("FindWorkspace() diff (-got,+want):\n%s", diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
When running `ibazel test` query the provided target pattern and
identify when there is only one target available. If there is a single
target invoke test with --test_output=streamed automatically.