### PR TITLE
Updaing the bazel build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ You can, of course, build iBazel using Bazel.
 ```
 $ git clone git@github.com:bazelbuild/bazel-watcher
 $ cd bazel-watcher
-$ bazel build //ibazel
+$ bazel build //cmd/ibazel
 ```
 
 Now copy the generated binary onto your path:
 
 ```bash
-$ export PATH=$PATH:$PWD/bazel-bin/ibazel/ibazel_/ibazel
+$ export PATH=$PATH:$PWD/bazel-bin/cmd/ibazel/ibazel_
 ```
 
 ## Running a target


### PR DESCRIPTION
After the new structure, the old bazel build command stops working because the target no longer exists. Updating the instructions to reflect the new structure.

Tested:

  cd "$(mktemp -d)"
  curl -L
  https://github.com/bazelbuild/bazel-watcher/archive/master.zip -o
  master.zip
  unzip master.zip
  cd bazel-watcher-master
  bazelisk build //cmd/ibazel:ibazel
  ls -lh "$PWD/bazel-bin/cmd/ibazel/ibazel_/ibazel"