### PR TITLE
Pass through necessary args for cquery

### DIFF
--- a/internal/e2e/incompatible_by_default/BUILD
+++ b/internal/e2e/incompatible_by_default/BUILD
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "incompatible_by_default_test",
+    srcs = ["incompatible_by_default_test.go"],
+    deps = [
+        "//internal/e2e",
+        "@io_bazel_rules_go//go/tools/bazel_testing:go_default_library",
+    ],
+)

--- a/internal/e2e/incompatible_by_default/incompatible_by_default_test.go
+++ b/internal/e2e/incompatible_by_default/incompatible_by_default_test.go
@@ -1,0 +1,86 @@
+package simple
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/bazelbuild/bazel-watcher/internal/e2e"
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+const mainFiles = `
+-- BUILD.bazel --
+constraint_setting(
+	name = "constraint_setting",
+	default_constraint_value = ":constraint1",
+)
+constraint_value(
+	name = "constraint1",
+	constraint_setting = "constraint_setting",
+)
+constraint_value(
+	name = "constraint2",
+	constraint_setting = "constraint_setting",
+)
+
+platform(
+	name = "platform1",
+	constraint_values = [
+		":constraint1",
+	],
+)
+platform(
+	name = "platform2",
+	constraint_values = [
+		":constraint2",
+	],
+)
+
+sh_binary(
+	name = "incompatible_by_default",
+	srcs = ["incompatible_by_default.sh"],
+	target_compatible_with = [
+		":constraint2",
+	],
+)
+-- incompatible_by_default.sh --
+#!/bin/bash
+echo 'hello!'
+-- WORKSPACE --
+-- .bazelrc --
+build:platform2 --platforms=//:platform2
+`
+
+var (
+	secondaryWd string
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: mainFiles,
+		SetUp: func() error {
+			path := "incompatible_by_default.sh"
+			if err := os.Chmod(path, 0777); err != nil {
+				return fmt.Errorf("Error os.Chmod(%q, 0777): %v", path, err)
+			}
+			return nil
+		},
+	})
+}
+
+func TestRunWithPlatforms(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	ibazel.Run([]string{"--platforms=//:platform2"}, "//:incompatible_by_default")
+	defer ibazel.Kill()
+
+	ibazel.ExpectOutput("hello!")
+}
+
+func TestRunWithConfig(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	ibazel.Run([]string{"--config=platform2"}, "//:incompatible_by_default")
+	defer ibazel.Kill()
+
+	ibazel.ExpectOutput("hello!")
+}

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -447,7 +447,7 @@ func (i *IBazel) queryRule(rule string) (*blaze_query.Rule, error) {
 	b.WriteToStderr(false)
 	b.WriteToStdout(false)
 
-	res, err := b.CQuery(i.queryArgs(rule)...)
+	res, err := b.CQuery(i.cQueryArgs(rule)...)
 	if err != nil {
 		log.Errorf("Error running Bazel %v", err)
 		osExit(4)
@@ -569,6 +569,13 @@ func (i *IBazel) queryArgs(args ...string) []string {
 	}
 
 	return queryArgs
+}
+
+func (i *IBazel) cQueryArgs(args ...string) []string {
+	// Unlike query, cquery can be affected by the majority of command line option.
+	cQueryArgs := append([]string(nil), args...)
+	cQueryArgs = append(cQueryArgs, i.bazelArgs...)
+	return cQueryArgs
 }
 
 func parseTarget(label string) (repo string, target string) {


### PR DESCRIPTION
`ibazel` runs an initial `cquery` on startup. Unfortunately, it does
not pass through command line arguments other than
`--override_repository`. That means we're not passing through things
like `--platforms`. That in turn means the target being queried can
actually be incompatible and the query will fail.

This patch fixes the situation by passing all bazel options through to
the `cquery`.

The new test validates just 2 of the ways a `cquery` requires more
command line arguments than what it has been getting.