### PR TITLE
Add startup arg --bazel_base to the startup arg whitelist

### DIFF
--- a/cmd/ibazel/main.go
+++ b/cmd/ibazel/main.go
@@ -31,6 +31,7 @@ var overrideableStartupFlags []string = []string{
 	"--bazelrc",
 	"--home_rc",
 	"--nohome_rc",
+	"--output_base",
 }
 
 var overrideableBazelFlags []string = []string{

--- a/cmd/ibazel/main_test.go
+++ b/cmd/ibazel/main_test.go
@@ -34,7 +34,7 @@ func TestParsingArgs(t *testing.T) {
 		// arguments after a --.
 		{[]string{"--", "--my_program_flag"}, nil, nil, nil, []string{"--my_program_flag"}},
 		// Whitelisted startup argument.
-		{[]string{"--bazelrc=/home/libsamek/bazelrc", "--nohome_rc"}, nil, []string{"--bazelrc=/home/libsamek/bazelrc", "--nohome_rc"}, nil, nil},
+		{[]string{"--bazelrc=/home/libsamek/bazelrc", "--nohome_rc", "--output_base=/tmp/test-output-base"}, nil, []string{"--bazelrc=/home/libsamek/bazelrc", "--nohome_rc", "--output_base=/tmp/test-output-base"}, nil, nil},
 		// Whitelisted bazel flag.
 		{[]string{"--test_output=streaming"}, nil, nil, []string{"--test_output=streaming"}, nil},
 		// Whitelisted bazel flag, arg, and target.


### PR DESCRIPTION
Fixes  #549.