### PR TITLE
Adds --target_pattern_file into the iBazel proxied flags list

### DIFF
--- a/cmd/ibazel/main.go
+++ b/cmd/ibazel/main.go
@@ -64,6 +64,7 @@ var overrideableBazelFlags []string = []string{
 	"--show_result=",
 	"--stamp",
 	"--strategy=",
+	"--target_pattern_file=",
 	"--test_arg=",
 	"--test_env=",
 	"--test_filter=",


### PR DESCRIPTION
Docs here: https://bazel.build/reference/command-line-reference#flag--target_pattern_file

Basing this pull request on https://github.com/bazelbuild/bazel-watcher/pull/452