### PR TITLE
chore(NA): Add linux arm64 build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,14 @@ jobs:
             artifact: ibazel_linux_amd64
             os: ubuntu-18.04
             build_flags: --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
-            cpu_flag:
+            cpu_flag: 
+            ext: ""
+
+          - name: linux_arm64
+            artifact: ibazel_linux_amd64
+            os: ubuntu-18.04
+            build_flags: --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64
+            cpu_flag: --cpu=linux_arm64
             ext: ""
           
           - name: windows_amd64
@@ -102,6 +109,7 @@ jobs:
           mv darwin_amd64/ibazel_darwin_amd64 darwin_amd64/ibazel
           mv darwin_arm64/ibazel_darwin_arm64 darwin_arm64/ibazel
           mv linux_amd64/ibazel_linux_amd64 linux_amd64/ibazel
+          mv linux_arm64/ibazel_linux_arm64 linux_arm64/ibazel
           mv windows_amd64/ibazel_windows_amd64.exe windows_amd64/ibazel.exe
           chmod 755 */ibazel*
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
             artifact: ibazel_linux_amd64
             os: ubuntu-18.04
             build_flags: --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64
-            cpu_flag: --cpu=linux_arm64
+            cpu_flag:
             ext: ""
           
           - name: windows_amd64
@@ -43,7 +43,7 @@ jobs:
             artifact: ibazel_darwin_arm64
             os: macos-latest
             build_flags: --platforms=@io_bazel_rules_go//go/toolchain:darwin_arm64_cgo
-            cpu_flag: --cpu=darwin_arm64
+            cpu_flag:
             ext: ""
 
     steps:

--- a/internal/bazel/bazel_test.go
+++ b/internal/bazel/bazel_test.go
@@ -99,6 +99,7 @@ var bazelNpmPathTests = []struct {
 	err error
 }{
 	{"/node_modules/@bazel/ibazel/bin/linux_amd64/ibazel", os.Getenv("TEST_TMPDIR") + "/node_modules/@bazel/bazel-linux_x64/bazel-1.2.3-linux_x86_64", nil},
+	{"/node_modules/@bazel/ibazel/bin/linux_arm64/ibazel", os.Getenv("TEST_TMPDIR") + "/node_modules/@bazel/bazel-linux_arm64/bazel-1.2.3-linux_arm64", nil},
 	{"/node_modules/@bazel/ibazel/bin/windows_amd64/ibazel.exe", os.Getenv("TEST_TMPDIR") + "/node_modules/@bazel/bazel-windows_x64/bazel-1.2.3-windows_x86_64.exe", nil},
 	{"/node_modules/@bazel/ibazel/bin/darwin_amd64/ibazel", os.Getenv("TEST_TMPDIR") + "/node_modules/@bazel/bazel-darwin_x64/bazel-1.2.3-darwin_x86_64", nil},
 	{"/node_modules/@bazel/ibazel/bin/darwin_arm64/ibazel", os.Getenv("TEST_TMPDIR") + "/node_modules/@bazel/bazel-darwin_arm64/bazel-1.2.3-darwin_arm64", nil},
@@ -112,6 +113,9 @@ func TestBazelNpmPath(t *testing.T) {
 	if err := os.MkdirAll(bazelNpmDir+"/bazel-linux_x64", 0755); err != nil {
 		t.Errorf(err.Error())
 	}
+	if err := os.MkdirAll(bazelNpmDir+"/bazel-linux_arm64", 0755); err != nil {
+		t.Errorf(err.Error())
+	}
 	if err := os.MkdirAll(bazelNpmDir+"/bazel-windows_x64", 0755); err != nil {
 		t.Errorf(err.Error())
 	}
@@ -122,6 +126,9 @@ func TestBazelNpmPath(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	if _, err := os.Create(bazelNpmDir + "/bazel-linux_x64/bazel-1.2.3-linux_x86_64"); err != nil {
+		t.Errorf(err.Error())
+	}
+	if _, err := os.Create(bazelNpmDir + "/bazel-linux_arm64/bazel-1.2.3-linux_arm64"); err != nil {
 		t.Errorf(err.Error())
 	}
 	if _, err := os.Create(bazelNpmDir + "/bazel-windows_x64/bazel-1.2.3-windows_x86_64.exe"); err != nil {
@@ -152,6 +159,7 @@ var bazeliskNpmPathTests = []struct {
 	err error
 }{
 	{"/node_modules/@bazel/ibazel/bin/linux_amd64/ibazel", os.Getenv("TEST_TMPDIR") + "/node_modules/@bazel/bazelisk/bazelisk-linux_amd64", nil},
+	{"/node_modules/@bazel/ibazel/bin/linux_arm64/ibazel", os.Getenv("TEST_TMPDIR") + "/node_modules/@bazel/bazelisk/bazelisk-linux_arm64", nil},
 	{"/node_modules/@bazel/ibazel/bin/windows_amd64/ibazel.exe", os.Getenv("TEST_TMPDIR") + "/node_modules/@bazel/bazelisk/bazelisk-windows_amd64.exe", nil},
 	{"/node_modules/@bazel/ibazel/bin/darwin_amd64/ibazel", os.Getenv("TEST_TMPDIR") + "/node_modules/@bazel/bazelisk/bazelisk-darwin_amd64", nil},
 	{"/node_modules/@bazel/ibazel/bin/darwin_arm64/ibazel", os.Getenv("TEST_TMPDIR") + "/node_modules/@bazel/bazelisk/bazelisk-darwin_arm64", nil},
@@ -166,6 +174,9 @@ func TestBazeliskNpmPath(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 	if _, err := os.Create(bazeliskNpmDir + "/bazelisk-linux_amd64"); err != nil {
+		t.Errorf(err.Error())
+	}
+	if _, err := os.Create(bazeliskNpmDir + "/bazelisk-linux_arm64"); err != nil {
 		t.Errorf(err.Error())
 	}
 	if _, err := os.Create(bazeliskNpmDir + "/bazelisk-windows_amd64.exe"); err != nil {


### PR DESCRIPTION
fix: #517 

- Removed the legacy `--cpu` build flag for M1, and test it on my local M1 `❯ bazel run //cmd/ibazel --platforms=@io_bazel_rules_go//go/toolchain:darwin_arm64_cgo`
- I compiled and tested it that I can run it on a linux + arm64 platform - i.e. in a devcontainer using Linux image on M1.
  - I can also check in the devcontainer config if that's helpful for future development.

```bash
## inside devcontainer
# output to verify platform spec
vscode ➜ /workspaces/bazel-watcher $ uname -si
Linux aarch64

# build ibazel
vscode ➜ /workspaces/bazel-watcher $  bazel run //cmd/ibazel --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 

INFO: Analyzed target //cmd/ibazel:ibazel (0 packages loaded, 10258 targets configured).
INFO: Found 1 target...
Target //cmd/ibazel:ibazel up-to-date:
  bazel-bin/cmd/ibazel/ibazel_/ibazel
INFO: Elapsed time: 11.693s, Critical Path: 10.79s
INFO: 72 processes: 3 internal, 69 linux-sandbox.
INFO: Build completed successfully, 72 total actions
INFO: Build completed successfully, 72 total actions
iBazel - Version Development

A file watcher for Bazel. Whenever a source file used in a specified
target changes, run, build, or test the specified targets.

Usage:

ibazel build|test|run [flags] targets...

Example:
...
```