### PR TITLE
Fix typo for releasing arm64 linux

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
             ext: ""
 
           - name: linux_arm64
-            artifact: ibazel_linux_amd64
+            artifact: ibazel_linux_arm64
             os: ubuntu-18.04
             build_flags: --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64
             cpu_flag:


### PR DESCRIPTION
@achew22 I think I made a typo in https://github.com/bazelbuild/bazel-watcher/pull/578 🤦 

Also all the mac artifacts are gone in https://github.com/bazelbuild/bazel-watcher/releases/tag/v0.21.1.. Any ideas why?