### PR TITLE
Add bazel coverage support

### DIFF
--- a/cmd/ibazel/main.go
+++ b/cmd/ibazel/main.go
@@ -206,6 +206,8 @@ func handle(i *ibazel.IBazel, command string, args []string) {
 		i.Build(targets...)
 	case "test":
 		i.Test(targets...)
+	case "coverage":
+		i.Coverage(targets...)
 	case "run":
 		// Run only takes one target.
 		i.Run(targets[0], args)

--- a/internal/bazel/bazel.go
+++ b/internal/bazel/bazel.go
@@ -233,7 +233,7 @@ func (b *bazel) newCommand(command string, args ...string) (*bytes.Buffer, *byte
 // the bazel User Manual, and can be programmatically obtained with
 // 'bazel help info-keys'.
 //
-//   res, err := b.Info()
+// res, err := b.Info()
 func (b *bazel) Info() (map[string]string, error) {
 	b.WriteToStderr(false)
 	b.WriteToStdout(false)
@@ -279,15 +279,15 @@ func (b *bazel) processInfo(info string) (map[string]string, error) {
 //
 // For example, to show all C++ test rules in the strings package, use:
 //
-//   res, err := b.Query('kind("cc_.*test", strings:*)')
+// res, err := b.Query('kind("cc_.*test", strings:*)')
 //
 // or to find all dependencies of //path/to/package:target, use:
 //
-//   res, err := b.Query('deps(//path/to/package:target)')
+// res, err := b.Query('deps(//path/to/package:target)')
 //
 // or to find a dependency path between //path/to/package:target and //dependency:
 //
-//   res, err := b.Query('somepath(//path/to/package:target, //dependency)')
+// res, err := b.Query('somepath(//path/to/package:target, //dependency)')
 func (b *bazel) Query(args ...string) (*blaze_query.QueryResult, error) {
 	blazeArgs := append([]string(nil), "--output=proto", "--order_output=no", "--color=no")
 	blazeArgs = append(blazeArgs, args...)
@@ -318,15 +318,15 @@ func (b *bazel) processQuery(stdout []byte, stderr []byte) (*blaze_query.QueryRe
 //
 // For example, to show all C++ test rules in the strings package, use:
 //
-//   res, err := b.CQuery('kind("cc_.*test", strings:*)')
+// res, err := b.CQuery('kind("cc_.*test", strings:*)')
 //
 // or to find all dependencies of //path/to/package:target, use:
 //
-//   res, err := b.CQuery('deps(//path/to/package:target)')
+// res, err := b.CQuery('deps(//path/to/package:target)')
 //
 // or to find a dependency path between //path/to/package:target and //dependency:
 //
-//   res, err := b.CQuery('somepath(//path/to/package:target, //dependency)')
+// res, err := b.CQuery('somepath(//path/to/package:target, //dependency)')
 func (b *bazel) CQuery(args ...string) (*analysis.CqueryResult, error) {
 	blazeArgs := append([]string(nil), "--output=proto", "--color=no")
 	blazeArgs = append(blazeArgs, args...)

--- a/internal/e2e/ibazel.go
+++ b/internal/e2e/ibazel.go
@@ -74,9 +74,6 @@ func (i *IBazelTester) Test(bazelArgs []string, targets ...string) {
 	i.cmd = exec.Command(ibazelPath, args...)
 	i.t.Logf("ibazel invoked as: %s", strings.Join(i.cmd.Args, " "))
 
-	// print hello world
-	i.t.Logf("Hello World")
-
 	i.stdoutBuffer = &Buffer{}
 	i.cmd.Stdout = i.stdoutBuffer
 

--- a/internal/e2e/simple/simple_test.go
+++ b/internal/e2e/simple/simple_test.go
@@ -20,6 +20,16 @@ sh_binary(
   srcs = ["simple.sh"],
 )
 
+# Test and Coverage base case test
+sh_test(
+  name = "test_simple_test_failing",
+  srcs = ["test_simple_test_failing.sh"],
+)
+sh_test(
+  name = "test_simple_test_passing",
+  srcs = ["test_simple_test_passing.sh"],
+)
+
 # Environment variable tests
 sh_binary(
   name = "environment",
@@ -54,6 +64,10 @@ sh_binary(
 )
 -- subdir/subdir.sh --
 printf "Hello subdir!"
+-- test_simple_test_failing.sh --
+echo "1"
+-- test_simple_test_passing.sh --
+echo "0"
 `
 
 func TestMain(m *testing.M) {
@@ -68,6 +82,39 @@ func TestSimpleBuild(t *testing.T) {
 	defer ibazel.Kill()
 
 	ibazel.ExpectOutput("Started!")
+}
+
+func TestSimpleTestFailing(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	ibazel.Test([]string{}, "//:test_simple_test_failing")
+
+	ibazel.ExpectNoOutput()
+	ibazel.ExpectError("")
+}
+
+func TestSimpleTestPassing(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	ibazel.Test([]string{}, "//:test_simple_test_passing")
+	defer ibazel.Kill()
+
+	ibazel.ExpectOutput("1 test passes")
+	ibazel.ExpectNoError()
+}
+
+func TestSimpleCoverageFailing(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	ibazel.Coverage([]string{}, "//:test_simple_test_failing")
+
+	ibazel.ExpectError("")
+}
+
+func TestSimpleCoveragePassing(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	ibazel.Coverage([]string{}, "//:test_simple_test_passing")
+	defer ibazel.Kill()
+
+	ibazel.ExpectOutput("1 test passes")
+	ibazel.ExpectNoError()
 }
 
 func TestSimpleRunAfterShutdown(t *testing.T) {

--- a/internal/e2e/simple/simple_test.go
+++ b/internal/e2e/simple/simple_test.go
@@ -65,9 +65,11 @@ sh_binary(
 -- subdir/subdir.sh --
 printf "Hello subdir!"
 -- test_simple_test_failing.sh --
-echo "1"
+echo "I'm a failing test."
+exit 1
 -- test_simple_test_passing.sh --
-echo "0"
+echo "I'm a passing test."
+exit 0
 `
 
 func TestMain(m *testing.M) {
@@ -86,33 +88,37 @@ func TestSimpleBuild(t *testing.T) {
 
 func TestSimpleTestFailing(t *testing.T) {
 	ibazel := e2e.SetUp(t)
-	ibazel.Test([]string{}, "//:test_simple_test_failing")
+	ibazel.Test([]string{"--nocache_test_results", "--test_output=all"}, "//:test_simple_test_failing")
 
-	ibazel.ExpectNoOutput()
-	ibazel.ExpectError("")
+	ibazel.ExpectOutput("I'm a failing test.")
+	ibazel.ExpectError("FAIL")
 }
 
 func TestSimpleTestPassing(t *testing.T) {
 	ibazel := e2e.SetUp(t)
-	ibazel.Test([]string{}, "//:test_simple_test_passing")
+	ibazel.Test([]string{"--nocache_test_results", "--test_output=all"}, "//:test_simple_test_passing")
 	defer ibazel.Kill()
 
+	ibazel.ExpectOutput("I'm a passing test.")
 	ibazel.ExpectOutput("1 test passes")
 	ibazel.ExpectNoError()
 }
 
 func TestSimpleCoverageFailing(t *testing.T) {
 	ibazel := e2e.SetUp(t)
-	ibazel.Coverage([]string{}, "//:test_simple_test_failing")
+	ibazel.Coverage([]string{"--nocache_test_results", "--test_output=all"}, "//:test_simple_test_failing")
 
-	ibazel.ExpectError("")
+	ibazel.ExpectOutput("I'm a failing test.")
+	ibazel.ExpectOutput("FAIL")
+	ibazel.ExpectError("FAIL")
 }
 
 func TestSimpleCoveragePassing(t *testing.T) {
 	ibazel := e2e.SetUp(t)
-	ibazel.Coverage([]string{}, "//:test_simple_test_passing")
+	ibazel.Coverage([]string{"--nocache_test_results", "--test_output=all"}, "//:test_simple_test_passing")
 	defer ibazel.Kill()
 
+	ibazel.ExpectOutput("I'm a passing test.")
 	ibazel.ExpectOutput("1 test passes")
 	ibazel.ExpectNoError()
 }

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -263,6 +263,11 @@ func (i *IBazel) Test(targets ...string) error {
 	return i.loop("test", i.test, targets)
 }
 
+// Get code coverage for the specified targets in the IBazel loop.
+func (i *IBazel) Coverage(targets ...string) error {
+	return i.loop("coverage", i.test, targets)
+}
+
 func (i *IBazel) loop(command string, commandToRun runnableCommand, targets []string) error {
 	joinedTargets := strings.Join(targets, " ")
 


### PR DESCRIPTION
Fixes issue #448. I more or less followed the comments in the issue from @achew22. Then I added code to some other parts that were required. Let me know if I missed something else.
Apart from that, I also added a couple of very simple tests for the test and coverage commands to internal/e2e/simple/simple_test.go.