### PR TITLE
ibazel should uses --curses=yes

### DIFF
--- a/cmd/ibazel/main.go
+++ b/cmd/ibazel/main.go
@@ -44,7 +44,7 @@ var overrideableBazelFlags []string = []string{
 	"--compile_one_dependency",
 	"--config=",
 	"--copt=",
-	"--curses=no",
+	"--curses=yes",
 	"--cxxopt",
 	"-c",
 	"--define=",

--- a/cmd/ibazel/main.go
+++ b/cmd/ibazel/main.go
@@ -44,7 +44,7 @@ var overrideableBazelFlags []string = []string{
 	"--compile_one_dependency",
 	"--config=",
 	"--copt=",
-	"--curses=yes",
+	"--curses=",
 	"--cxxopt",
 	"-c",
 	"--define=",


### PR DESCRIPTION
ibazel is meant to be used interactively, by humans, where --curses=yes is the desired behavior.

--curses=auto is equivalent to --curses=no, because the bazel invocation is always wrapped by ibazel; and --curses=no is very frustrating to use because it results in something like this:

```
++ 2023-03-03T13:11:12-0800 ++ ibazel build //[target]
iBazel [1:11PM]: Querying for files to watch...
iBazel [1:11PM]: Building //[target]
INFO: Invocation ID: 4f3bfce8-a8cb-4ebe-8a21-137e69749a18
INFO: Streaming build results to: http://buildbuddy.[target]
Loading:
Loading: 0 packages loaded
Analyzing: target //[target]
INFO: Analyzed target //[target]
 checking cached actions
INFO: Found 1 target...
[0 / 136] [Prepa] BazelWorkspaceStatusAction stable-status.txt ... (4 actions, 1 running)
[193 / 1,176] Compiling src/google/protobuf/util/time_util.cc [for tool]; Downloading external/com_google_protobuf/_objs/protobuf/time_util.d; 0s remote-cache ... (19 actions, 0 running)
[495 / 2,053] Generating proto_library //[target]; Downloading [target]; 0s remote-cache ... (20 actions, 0 running)
INFO: From Generating Descriptor Set proto_library @com_github_cncf_udpa//xds/type/v3:pkg:
xds/type/v3/typed_struct.proto:10:1: warning: Import validate/validate.proto is unused.
[722 / 2,125] Compiling external/envoy_api/envoy/config/core/v3/extension.upbdefs.c; Downloading external/envoy_api/envoy/config/core/v3/_objs/pkg.upbdefs/extension.upbdefs.pic.o; 0s remote-cache ... (18 actions, 0 running)
[1,002 / 3,561] Compiling [target]; Downloading [target]; 0s remote-cache ... (28 actions, 16 running)
[1,100 / 3,699] Compiling [target]; 1s remote-cache, linux-sandbox ... (24 actions, 8 running)
[1,243 / 4,017] Compiling [target]; 2s remote-cache, linux-sandbox ... (21 actions, 2 running)
[1,412 / 4,520] Compiling [target]; 0s remote-cache, linux-sandbox ... (20 actions, 2 running)
[1,584 / 5,432] Compiling [target]; 1s remote-cache, linux-sandbox ... (21 actions, 2 running)
[1,635 / 5,519] Compiling src/google/protobuf/descriptor_database.cc; Downloading external/com_google_protobuf/_objs/protobuf/descriptor_database.pic.o; 1s remote-cache ... (19 actions, 0 running)
[1,741 / 5,626] Compiling src/google/protobuf/descriptor_database.cc; Downloading external/com_google_protobuf/_objs/protobuf/descriptor_database.pic.o; 2s remote-cache ... (17 actions, 0 running)
[1,868 / 5,854] Compiling src/google/protobuf/descriptor.cc; Downloading external/com_google_protobuf/_objs/protobuf/descriptor.pic.o, 3.8 MiB / 7.9 MiB; 2s remote-cache ... (20 actions, 0 running)
[1,970 / 5,854] Compiling [target]; 0s remote-cache ... (19 actions, 0 running)
[2,099 / 5,854] Linking external/com_google_protobuf/libprotobuf.so; Downloading external/com_google_protobuf/libprotobuf.so, 3.8 MiB / 23.9 MiB; 1s remote-cache ... (21 actions, 2 running)
[2,216 / 5,854] Linking external/com_google_protobuf/libprotobuf.so; Downloading external/com_google_protobuf/libprotobuf.so, 7.5 MiB / 23.9 MiB; 2s remote-cache ... (21 actions, 2 running)
[2,329 / 5,854] Linking external/com_google_protobuf/libprotobuf.so; Downloading external/com_google_protobuf/libprotobuf.so, 15 MiB / 23.9 MiB; 3s remote-cache ... (20 actions, 0 running)
[2,474 / 5,854] Compiling lib/doh.c; 0s remote-cache ... (20 actions, 0 running)
[2,584 / 5,854] Compiling handler/crash_report_upload_thread.cc; Downloading external/crashpad/_objs/crashpad/crash_report_upload_thread.pic.o; 0s remote-cache ... (19 actions, 0 running)
[2,648 / 5,854] Compiling minidump/minidump_file_writer.cc; Downloading external/crashpad/_objs/crashpad/minidump_file_writer.pic.o; 0s remote-cache ... (20 actions, 0 running)
[2,721 / 5,854] Compiling snapshot/minidump/process_snapshot_minidump.cc; Downloading external/crashpad/_objs/crashpad/process_snapshot_minidump.pic.o; 1s remote-cache ... (16 actions, 0 running)
[2,831 / 5,854] Linking external/boringssl/libssl.so; Downloading external/boringssl/libssl.so; 0s remote-cache ... (19 actions, 0 running)
[2,961 / 5,854] Linking external/crashpad/libcrashpad.so; Downloading external/crashpad/libcrashpad.so, 7.5 MiB / 21.2 MiB; 1s remote-cache ... (18 actions, 0 running)
[3,091 / 5,854] Linking external/crashpad/libcrashpad.so; Downloading external/crashpad/libcrashpad.so, 15 MiB / 21.2 MiB; 2s remote-cache ... (18 actions, 0 running)
[3,158 / 5,854] Linking external/crashpad/libcrashpad.so; 3s remote-cache ... (20 actions, 0 running)
[3,222 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 3.8 MiB / 48.1 MiB; 1s remote-cache ... (19 actions, 0 running)
[3,301 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 7.5 MiB / 48.1 MiB; 2s remote-cache ... (20 actions, 0 running)
[3,376 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 7.5 MiB / 48.1 MiB; 3s remote-cache ... (18 actions, 0 running)
[3,439 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 11.2 MiB / 48.1 MiB; 4s remote-cache ... (20 actions, 0 running)
[3,522 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 15 MiB / 48.1 MiB; 5s remote-cache ... (19 actions, 0 running)
[3,608 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 18.8 MiB / 48.1 MiB; 6s remote-cache ... (20 actions, 0 running)
[3,656 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 18.8 MiB / 48.1 MiB; 7s remote-cache ... (20 actions, 0 running)
[3,710 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 18.8 MiB / 48.1 MiB; 8s remote-cache ... (20 actions, 0 running)
[3,758 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 18.8 MiB / 48.1 MiB; 9s remote-cache ... (20 actions, 0 running)
[3,831 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 22.5 MiB / 48.1 MiB; 10s remote-cache ... (19 actions, 0 running)
[3,907 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 26.2 MiB / 48.1 MiB; 11s remote-cache ... (20 actions, 0 running)
[3,984 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 30 MiB / 48.1 MiB; 12s remote-cache ... (20 actions, 0 running)
[4,060 / 5,854] Compiling aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3-crt/S3CrtClient.pic.o, 41.2 MiB / 48.1 MiB; 13s remote-cache ... (20 actions, 0 running)
[4,151 / 5,854] Compiling aws-cpp-sdk-s3/source/S3Client.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3/S3Client.pic.o, 15 MiB / 47.4 MiB; 3s remote-cache ... (20 actions, 0 running)
[4,267 / 5,854] Compiling aws-cpp-sdk-s3/source/S3Client.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3/S3Client.pic.o, 18.8 MiB / 47.4 MiB; 4s remote-cache ... (20 actions, 0 running)
[4,389 / 5,854] Compiling aws-cpp-sdk-s3/source/S3Client.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3/S3Client.pic.o, 22.5 MiB / 47.4 MiB; 5s remote-cache ... (20 actions, 0 running)
[4,526 / 5,855] Compiling aws-cpp-sdk-s3/source/S3Client.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3/S3Client.pic.o, 30 MiB / 47.4 MiB; 6s remote-cache ... (20 actions, 0 running)
[4,554 / 5,855] Compiling aws-cpp-sdk-s3/source/S3Client.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3/S3Client.pic.o, 33.8 MiB / 47.4 MiB; 7s remote-cache ... (19 actions, 0 running)
[4,572 / 5,855] Compiling aws-cpp-sdk-s3/source/S3Client.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3/S3Client.pic.o, 33.8 MiB / 47.4 MiB; 8s remote-cache ... (20 actions, 0 running)
[4,594 / 5,855] Compiling aws-cpp-sdk-s3/source/S3Client.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3/S3Client.pic.o, 41.2 MiB / 47.4 MiB; 9s remote-cache ... (19 actions, 0 running)
[4,623 / 5,855] Compiling aws-cpp-sdk-s3/source/S3Client.cpp; Downloading external/aws/_objs/aws-cpp-sdk-s3/S3Client.pic.o, 45 MiB / 47.4 MiB; 10s remote-cache ... (20 actions, 0 running)
[4,659 / 5,855] Linking external/aws/libaws-cpp-sdk-s3-crt.so; Downloading external/aws/libaws-cpp-sdk-s3-crt.so, 33.8 MiB / 63.5 MiB; 8s remote-cache ... (18 actions, 0 running)
[4,693 / 5,855] Linking external/aws/libaws-cpp-sdk-s3-crt.so; Downloading external/aws/libaws-cpp-sdk-s3-crt.so, 41.2 MiB / 63.5 MiB; 9s remote-cache ... (20 actions, 0 running)
[4,754 / 5,855] Linking external/aws/libaws-cpp-sdk-s3-crt.so; Downloading external/aws/libaws-cpp-sdk-s3-crt.so, 52.5 MiB / 63.5 MiB; 10s remote-cache ... (20 actions, 0 running)
[4,816 / 5,855] Linking external/aws/libaws-cpp-sdk-s3-crt.so; 11s remote-cache ... (20 actions, 0 running)
[4,856 / 5,855] Linking external/aws/libaws-cpp-sdk-s3.so; Downloading external/aws/libaws-cpp-sdk-s3.so, 18.8 MiB / 62.6 MiB; 4s remote-cache ... (21 actions, 2 running)
[4,901 / 5,855] Linking external/aws/libaws-cpp-sdk-s3.so; Downloading external/aws/libaws-cpp-sdk-s3.so, 26.2 MiB / 62.6 MiB; 5s remote-cache ... (21 actions, 2 running)
[4,957 / 5,855] Linking external/aws/libaws-cpp-sdk-s3.so; Downloading external/aws/libaws-cpp-sdk-s3.so, 33.8 MiB / 62.6 MiB; 6s remote-cache ... (21 actions, 2 running)
[5,011 / 5,855] Linking external/aws/libaws-cpp-sdk-s3.so; Downloading external/aws/libaws-cpp-sdk-s3.so, 45 MiB / 62.6 MiB; 7s remote-cache ... (21 actions, 2 running)
[5,062 / 5,855] Linking external/aws/libaws-cpp-sdk-s3.so; Downloading external/aws/libaws-cpp-sdk-s3.so, 52.5 MiB / 62.6 MiB; 8s remote-cache ... (21 actions, 2 running)
[5,123 / 5,855] Compiling [target]; 5s remote-cache, linux-sandbox ... (21 actions, 2 running)
[5,202 / 5,855] Compiling [target]; 6s remote-cache, linux-sandbox ... (21 actions, 2 running)
[5,263 / 5,855] Compiling [target]; 7s remote-cache, linux-sandbox ... (21 actions, 2 running)
[5,301 / 5,855] Compiling [target]; 8s remote-cache, linux-sandbox ... (21 actions, 2 running)
[5,345 / 5,855] Compiling [target]; 9s remote-cache, linux-sandbox ... (21 actions, 2 running)
[5,395 / 5,855] Compiling [target]; 10s remote-cache, linux-sandbox ... (20 actions, 2 running)
[5,435 / 5,855] Compiling [target]; 11s remote-cache, linux-sandbox ... (21 actions, 2 running)
[5,464 / 5,855] Linking external/com_github_grpc_grpc/libgrpc++_binder.so; Downloading external/com_github_grpc_grpc/libgrpc++_binder.so; 2s remote-cache ... (20 actions, 1 running)
[5,497 / 5,855] Linking external/com_github_grpc_grpc/libgrpc++_binder.so; Downloading external/com_github_grpc_grpc/libgrpc++_binder.so, 3.8 MiB / 9.6 MiB; 3s remote-cache ... (21 actions, 2 running)
[5,532 / 5,856] Linking external/com_github_grpc_grpc/libgrpc++_binder.so; Downloading external/com_github_grpc_grpc/libgrpc++_binder.so, 7.5 MiB / 9.6 MiB; 4s remote-cache ... (21 actions, 2 running)
[5,558 / 5,856] Linking external/com_github_grpc_grpc/libgrpc_base.so; Downloading external/com_github_grpc_grpc/libgrpc_base.so, 11.2 MiB / 14.2 MiB; 4s remote-cache ... (20 actions, 0 running)
[5,575 / 5,856] Compiling [target]; Downloading [target]; 1s remote-cache ... (27 actions, 14 running)
[5,584 / 5,856] Compiling [target]; 2s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,584 / 5,856] Compiling [target]; 3s remote-cache, linux-sandbox ... (40 actions running)
[5,585 / 5,856] Compiling [target]; 5s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,587 / 5,856] Compiling [target]; 7s remote-cache, linux-sandbox ... (40 actions running)
[5,588 / 5,856] Compiling [target]; 8s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,595 / 5,856] Compiling [target]; 9s remote-cache, linux-sandbox ... (37 actions, 36 running)
[5,598 / 5,856] Compiling [target]; 10s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,599 / 5,856] Compiling [target]; 11s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,601 / 5,856] Compiling [target]; 12s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,604 / 5,856] Compiling [target]; 14s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,608 / 5,856] Compiling [target]; 14s remote-cache, linux-sandbox ... (40 actions running)
[5,609 / 5,856] Compiling [target]; 16s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,613 / 5,856] Compiling [target]; 17s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,617 / 5,856] Compiling [target]; 18s remote-cache, linux-sandbox ... (40 actions running)
[5,627 / 5,856] Compiling [target]; 19s remote-cache, linux-sandbox ... (37 actions, 34 running)
[5,643 / 5,856] Compiling [target]; 8s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,649 / 5,856] Compiling [target]; 7s remote-cache, linux-sandbox ... (38 actions, 36 running)
[5,650 / 5,856] Compiling [target]; 8s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,651 / 5,856] Compiling [target]; 8s remote-cache, linux-sandbox ... (40 actions running)
[5,652 / 5,856] Compiling [target]; 9s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,656 / 5,856] Compiling [target]; 8s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,657 / 5,856] Compiling [target]; 9s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,658 / 5,856] Compiling [target]; 11s remote-cache, linux-sandbox ... (38 actions, 36 running)
[5,659 / 5,856] Compiling [target]; 12s remote-cache, linux-sandbox ... (38 actions, 36 running)
[5,663 / 5,856] Compiling [target]; 11s remote-cache, linux-sandbox ... (40 actions running)
[5,664 / 5,856] Compiling [target]; 13s remote-cache, linux-sandbox ... (40 actions running)
[5,665 / 5,856] Compiling [target]; 16s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,666 / 5,856] Compiling [target]; 17s remote-cache, linux-sandbox ... (38 actions running)
[5,667 / 5,856] Compiling [target]; 19s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,667 / 5,856] Compiling [target]; 20s remote-cache, linux-sandbox ... (40 actions running)
[5,668 / 5,856] Compiling [target]; 21s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,669 / 5,856] Compiling [target]; 22s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,673 / 5,856] Compiling [target]; 23s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,675 / 5,856] Compiling [target]; 25s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,677 / 5,856] Compiling [target]; 26s remote-cache, linux-sandbox ... (40 actions running)
[5,678 / 5,856] Compiling [target]; 27s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,680 / 5,856] Compiling [target]; 28s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,682 / 5,856] Compiling [target]; 23s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,682 / 5,856] Compiling [target]; 24s remote-cache, linux-sandbox ... (40 actions running)
[5,683 / 5,856] Compiling [target]; 22s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,685 / 5,856] Compiling [target]; 24s remote-cache, linux-sandbox ... (40 actions running)
[5,686 / 5,856] Compiling [target]; 27s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,687 / 5,856] Compiling [target]; 22s remote-cache, linux-sandbox ... (40 actions running)
[5,688 / 5,856] Compiling [target]; 19s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,690 / 5,856] Compiling [target]; 20s remote-cache, linux-sandbox ... (40 actions running)
[5,690 / 5,856] Compiling [target]; 21s remote-cache, linux-sandbox ... (40 actions running)
[5,693 / 5,856] Compiling [target]; 22s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,694 / 5,856] Compiling [target]; 23s remote-cache, linux-sandbox ... (40 actions running)
[5,695 / 5,856] Compiling [target]; 27s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,695 / 5,856] Compiling [target]; 28s remote-cache, linux-sandbox ... (40 actions running)
[5,696 / 5,856] Compiling [target]; 30s remote-cache, linux-sandbox ... (40 actions running)
[5,698 / 5,856] Compiling [target]; 30s remote-cache, linux-sandbox ... (38 actions running)
[5,701 / 5,856] Compiling [target]; 31s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,701 / 5,856] Compiling [target]; 33s remote-cache, linux-sandbox ... (40 actions running)
[5,704 / 5,856] Compiling [target]; 34s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,706 / 5,856] Compiling [target]; 35s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,707 / 5,856] Compiling [target]; 36s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,708 / 5,856] Compiling [target]; 38s remote-cache, linux-sandbox ... (40 actions running)
[5,710 / 5,856] Compiling [target]; 40s remote-cache, linux-sandbox ... (40 actions running)
[5,711 / 5,856] Compiling [target]; 41s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,716 / 5,856] Compiling [target]; 25s remote-cache, linux-sandbox ... (38 actions, 36 running)
[5,724 / 5,856] Compiling [target]; 26s remote-cache, linux-sandbox ... (37 actions, 34 running)
[5,727 / 5,856] Compiling [target]; 24s remote-cache, linux-sandbox ... (38 actions, 36 running)
[5,730 / 5,856] Compiling [target]; 15s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,730 / 5,856] Compiling [target]; 17s remote-cache, linux-sandbox ... (40 actions running)
[5,731 / 5,856] Compiling [target]; 18s remote-cache, linux-sandbox ... (39 actions, 38 running)
[5,731 / 5,856] Compiling [target]; 20s remote-cache, linux-sandbox ... (40 actions running)
[5,733 / 5,856] Compiling [target]; 20s remote-cache, linux-sandbox ... (40 actions running)
[5,735 / 5,856] Compiling [target]; 22s remote-cache, linux-sandbox ... (40 actions running)
[5,736 / 5,856] Compiling [target]; 25s remote-cache, linux-sandbox ... (39 actions, 38 running)
```