### PR TITLE
feat: add detection for isatty

### DIFF
--- a/cmd/ibazel/BUILD.bazel
+++ b/cmd/ibazel/BUILD.bazel
@@ -4,6 +4,8 @@ go_library(
     name = "ibazel_lib",
     srcs = [
         "main.go",
+        "main_bsd.go",
+        "main_linux.go",
         "main_unix.go",
         "main_windows.go",
     ],

--- a/cmd/ibazel/BUILD.bazel
+++ b/cmd/ibazel/BUILD.bazel
@@ -12,7 +12,15 @@ go_library(
     deps = [
         "//internal/ibazel",
         "//internal/ibazel/log",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_binary(

--- a/cmd/ibazel/main.go
+++ b/cmd/ibazel/main.go
@@ -51,6 +51,7 @@ var overrideableBazelFlags []string = []string{
 	"--dynamic_mode=",
 	"--features=",
 	"--flaky_test_attempts=",
+	"--isatty=",
 	"--keep_going",
 	"-k",
 	"--nocache_test_results",
@@ -196,8 +197,24 @@ func main() {
 	handle(i, command, args)
 }
 
+func applyDefaultBazelArgs(bazelArgs []string) []string {
+	for _, bazelArg := range bazelArgs {
+		if strings.HasPrefix(bazelArg, "--isatty=") {
+			return bazelArgs
+		}
+	}
+	if (isTerminal()) {
+		return append(bazelArgs, "--isatty=1")
+	} else {
+		return append(bazelArgs, "--isatty=0")
+	}
+}
+
 func handle(i *ibazel.IBazel, command string, args []string) {
 	targets, startupArgs, bazelArgs, args := parseArgs(args)
+
+	bazelArgs = applyDefaultBazelArgs(bazelArgs)
+
 	i.SetStartupArgs(startupArgs)
 	i.SetBazelArgs(bazelArgs)
 

--- a/cmd/ibazel/main_bsd.go
+++ b/cmd/ibazel/main_bsd.go
@@ -1,0 +1,30 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build (darwin || freebsd || openbsd || netbsd || dragonfly || hurd)
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func isTerminal() bool {
+	_, err1 := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TIOCGETA)
+	_, err2 := unix.IoctlGetTermios(int(os.Stderr.Fd()), unix.TCGETS)
+
+	return err1 == nil && err2 == nil
+}

--- a/cmd/ibazel/main_bsd.go
+++ b/cmd/ibazel/main_bsd.go
@@ -24,7 +24,7 @@ import (
 
 func isTerminal() bool {
 	_, err1 := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TIOCGETA)
-	_, err2 := unix.IoctlGetTermios(int(os.Stderr.Fd()), unix.TCGETS)
+	_, err2 := unix.IoctlGetTermios(int(os.Stderr.Fd()), unix.TIOCGETA)
 
 	return err1 == nil && err2 == nil
 }

--- a/cmd/ibazel/main_linux.go
+++ b/cmd/ibazel/main_linux.go
@@ -1,0 +1,31 @@
+
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build (linux || aix || zos)
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func isTerminal() bool {
+	_, err1 := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TCGETS)
+	_, err2 := unix.IoctlGetTermios(int(os.Stderr.Fd()), unix.TCGETS)
+
+	return err1 == nil && err2 == nil
+}

--- a/cmd/ibazel/main_unix.go
+++ b/cmd/ibazel/main_unix.go
@@ -12,24 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+//go:build !windows
 
 package main
 
 import (
-	"os"
 	"runtime"
 	"syscall"
-
-	"golang.org/x/sys/unix"
 )
-
-func isTerminal() bool {
-	_, err1 := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TCGETS)
-	_, err2 := unix.IoctlGetTermios(int(os.Stderr.Fd()), unix.TCGETS)
-
-	return err1 == nil && err2 == nil
-}
 
 func setUlimit() error {
 	var lim syscall.Rlimit

--- a/cmd/ibazel/main_unix.go
+++ b/cmd/ibazel/main_unix.go
@@ -17,9 +17,19 @@
 package main
 
 import (
+	"os"
 	"runtime"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
+
+func isTerminal() bool {
+	_, err1 := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TCGETS)
+	_, err2 := unix.IoctlGetTermios(int(os.Stderr.Fd()), unix.TCGETS)
+
+	return err1 == nil && err2 == nil
+}
 
 func setUlimit() error {
 	var lim syscall.Rlimit

--- a/cmd/ibazel/main_windows.go
+++ b/cmd/ibazel/main_windows.go
@@ -14,6 +14,10 @@
 
 package main
 
+func isTerminal() bool {
+	return false
+}
+
 func setUlimit() error {
 	return nil
 }


### PR DESCRIPTION
This is subpar compared to what Bazel can autodetect, but it's better than nothing.

Bazel's `--curses=auto` is implemented by [passing to itself a flag `--isatty=`](https://github.com/bazelbuild/bazel/blob/bd011cdeddeb9750468612bb89ea9f189fcbd726/src/main/cpp/option_processor.cc#L661-L662), which is computed using [platform-specific logic](https://github.com/bazelbuild/bazel/blob/bd011cdeddeb9750468612bb89ea9f189fcbd726/src/main/cpp/blaze_util_posix.cc#L770-L786).

Upgrade build directives to `//go:build` since this directive is now preferred since go 1.18.

Borrows from [mattn/go-isatty](https://github.com/mattn/go-isatty).