### PR TITLE
Embedding is now better handled by using rules_go's built-in embedding functionality #601 Fix

### DIFF
--- a/internal/ibazel/profiler/BUILD
+++ b/internal/ibazel/profiler/BUILD
@@ -12,20 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_embed_data", "go_library")
-
-go_embed_data(
-    name = "js",
-    src = "profiler.js",
-    package = "profiler",
-    var = "js",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "profiler",
     srcs = [
         "profiler.go",
-        ":js",  # keep
+    ],
+    embedsrcs = [
+        "profiler.js", # Add this line to embed the profiler.js file
     ],
     importpath = "github.com/bazelbuild/bazel-watcher/internal/ibazel/profiler",
     visibility = ["//:__subpackages__"],

--- a/internal/ibazel/profiler/profiler.go
+++ b/internal/ibazel/profiler/profiler.go
@@ -16,10 +16,12 @@ package profiler
 
 import (
 	"bytes"
+	"embed"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	golog "log"
 	"math/rand"
 	"net"
@@ -34,6 +36,8 @@ import (
 )
 
 var profileDev = flag.String("profile_dev", "", "Turn on profiling and append report to file")
+
+var js embed.FS
 
 const (
 
@@ -338,9 +342,18 @@ func (i *Profiler) jsHandler(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	rw.Header().Set("Content-Type", "application/javascript")
-	_, err := rw.Write(js)
+
+	// Read the content of profiler.js into a []byte variable
+	content, err := fs.ReadFile(js, "profiler.js")
 	if err != nil {
-		log.Errorf("Error handling profile.js request: %v", err)
+			log.Errorf("Error reading profiler.js: %v", err)
+			return
+	}
+
+	// Write the content to the response writer
+	_, err = rw.Write(content)
+	if err != nil {
+			log.Errorf("Error handling profile.js request: %v", err)
 	}
 }
 


### PR DESCRIPTION
The `go_embed_data` rule is deprecated and will be removed in rules_go version 0.39.

This commit upgrades Embedding is now handled using rules_go's built-in embedding functionality.

