### PR TITLE
Fix buildfiles query

### DIFF
--- a/internal/ibazel/BUILD
+++ b/internal/ibazel/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//internal/ibazel/profiler",
         "//internal/ibazel/workspace",
         "//third_party/bazel/master/src/main/protobuf/blaze_query",
+        "//third_party/bazel/master/src/main/protobuf/analysis",
     ],
 )
 

--- a/internal/ibazel/ibazel_test.go
+++ b/internal/ibazel/ibazel_test.go
@@ -188,7 +188,7 @@ func TestIBazelLoop(t *testing.T) {
 	log.SetTesting(t)
 
 	i, mockBazel := newIBazel(t)
-	mockBazel.AddCQueryResponse("buildfiles(deps(set(//my:target)))", &analysispb.CqueryResult{})
+	mockBazel.AddQueryResponse("buildfiles(deps(set(//my:target)))", &blaze_query.QueryResult{})
 	mockBazel.AddCQueryResponse("kind('source file', deps(set(//my:target)))", &analysispb.CqueryResult{})
 
 	// Replace the file watching channel with one that has a buffer.
@@ -271,6 +271,20 @@ func TestIBazelBuild(t *testing.T) {
 
 	i, mockBazel := newIBazel(t)
 	defer i.Cleanup()
+
+	mockBazel.AddQueryResponse("//path/to:target", &blaze_query.QueryResult{
+		Target: []*blaze_query.Target{
+			{
+				Type: blaze_query.Target_RULE.Enum(),
+				Rule: &blaze_query.Rule{
+					Name: proto.String("//path/to:target"),
+					Attribute: []*blaze_query.Attribute{
+						{Name: proto.String("name")},
+					},
+				},
+			},
+		},
+	})
 
 	mockBazel.AddCQueryResponse("//path/to:target", &analysispb.CqueryResult{
 		Results: []*analysispb.ConfiguredTarget{{


### PR DESCRIPTION
## What?
Commit ac2ce9f7406798b10c584efbac14ca05ba8cd818 introduced a change where bazel-watcher uses cquery instead of query to get the files to watch. This works well for source files but the `buildfiles` keyword is not supported in cquery so the query for BUILD files fails.

This change uses cquery for source files and query for BUILD files.

Fixes #603