### PR TITLE
Add --check_visibility bazel arg

### DIFF
--- a/cmd/ibazel/main.go
+++ b/cmd/ibazel/main.go
@@ -40,6 +40,7 @@ var overrideableBazelFlags []string = []string{
 	"--aspects",
 	"--build_tag_filters=",
 	"--build_tests_only",
+	"--check_visibility=",
 	"--compilation_mode",
 	"--compile_one_dependency",
 	"--config=",


### PR DESCRIPTION
Allows you to use the `--check_visibility` bazel arg with ibazel.

Tested by building with bazel `bazel build //cmd/ibazel` and verifying that the `--check_visibility` argument can be used with the newly built binary.