### PR TITLE
chore(release): don't use bazelisk from npm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,13 +56,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-
-      - name: Install Bazelisk
-        run: npm --global install @bazel/bazelisk@latest
-
       - name: Build ibazel 
         run: bazel build //cmd/ibazel:ibazel --config release ${{ matrix.build_flags }} ${{ matrix.cpu_flag }}
       
@@ -100,12 +93,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: ./npm-staging/bin
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-
-      - name: Install Bazelisk
-        run: npm --global install @bazel/bazelisk@latest
 
       - name: Prepare ibazel binaries
         working-directory: ./npm-staging/bin


### PR DESCRIPTION
GitHub's default action runners image now includes bazelisk on the machine, so we are free to call `bazel` commands and be safe knowing the right version of Bazel will run.

A step before debugging why our npm package doesn't publish, likely not related, but @josephperrott points out we have some extra setup-node `uses` which is not desirable.