### PR TITLE
fix(npm releases): match environment variable with GHA

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 # NPM_TOKEN read from env or GH Secret (.github/workflows/release.yaml)
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}


### PR DESCRIPTION
https://github.com/bazelbuild/bazel-watcher/commit/a55698e358013fd43a5898b2b319cbffc2abedb8 changed the environment variable being set from GitHub Actions, following the naming convention suggested by the documentation.

However, we weren't using the same name in the .npmrc file that we copy into the working directory, and this one gets used instead of the one created by actions/setup-node.