### PR TITLE
feat(keep_going) Support keep going when querying for source files 

### DIFF
--- a/internal/bazel/bazel.go
+++ b/internal/bazel/bazel.go
@@ -308,6 +308,9 @@ func (b *bazel) Query(args ...string) (*blaze_query.QueryResult, error) {
 				// Bazel exit code 3 means the build / query still succeeded with some errors (default behavior with --keep_going) 
 				return b.processQuery(stdoutBuffer.Bytes(), stderrBuff.Bytes())
 			}
+			else {
+				return nil, Err
+			}
 		} else {
 			return nil, err
 		}

--- a/internal/bazel/bazel.go
+++ b/internal/bazel/bazel.go
@@ -309,7 +309,7 @@ func (b *bazel) Query(args ...string) (*blaze_query.QueryResult, error) {
 				return b.processQuery(stdoutBuffer.Bytes(), stderrBuff.Bytes())
 			}
 			
-			return nil, err;
+			return nil, err
 		} else {
 			return nil, err
 		}

--- a/internal/bazel/bazel.go
+++ b/internal/bazel/bazel.go
@@ -308,9 +308,8 @@ func (b *bazel) Query(args ...string) (*blaze_query.QueryResult, error) {
 				// Bazel exit code 3 means the build / query still succeeded with some errors (default behavior with --keep_going) 
 				return b.processQuery(stdoutBuffer.Bytes(), stderrBuff.Bytes())
 			}
-			else {
-				return nil, Err
-			}
+			
+			return nil, err;
 		} else {
 			return nil, err
 		}

--- a/internal/bazel/bazel.go
+++ b/internal/bazel/bazel.go
@@ -299,9 +299,7 @@ func (b *bazel) Query(args ...string) (*blaze_query.QueryResult, error) {
 	err := b.cmd.Run()
 
 	if err != nil {
-		// If the command exits with an error, check if it's an ExitError
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			// Get the exit code from the ExitError
 			exitCode := exitErr.ExitCode()
 			if (exitCode == 3) {
 				log.Logf("WARNING: Query failed but exited with code 3. This might be because --keep_going is enabled...")

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -571,6 +571,9 @@ func (i *IBazel) queryArgs(args ...string) []string {
 		if strings.HasPrefix(arg, "--override_repository=") {
 			queryArgs = append(queryArgs, arg)
 		}
+		if arg == "--keep_going" {
+			queryArgs = append(queryArgs, arg)
+		}
 	}
 
 	return queryArgs


### PR DESCRIPTION
Ran into an issue with ibazel where if --keep_going was enabled, ibazel would not watch on the files that were ouputted by keep_going, it would just fail if the query was faulty. This is because the watch query didn't support the keep_going flag and didn't look at the exit code of the query. This PR adds that functionality to ibazel. Now querying source files will still work if keep_going is enabled. 

Looks like there aren't tests to Query and CQuery in the codebase right now, so let me know if you want me to add some. I'll keep the PR as is for now. 
