### PR TITLE
fix: use go:embed  instead of go_embed_data

### DIFF
--- a/internal/ibazel/profiler/BUILD
+++ b/internal/ibazel/profiler/BUILD
@@ -14,19 +14,13 @@
 
 load("@io_bazel_rules_go//go:def.bzl", "go_embed_data", "go_library")
 
-go_embed_data(
-    name = "js",
-    src = "profiler.js",
-    package = "profiler",
-    var = "js",
-)
 
 go_library(
     name = "profiler",
     srcs = [
         "profiler.go",
-        ":js",  # keep
     ],
+    embedsrcs = ["profiler.js"],
     importpath = "github.com/bazelbuild/bazel-watcher/internal/ibazel/profiler",
     visibility = ["//:__subpackages__"],
     deps = [

--- a/internal/ibazel/profiler/BUILD
+++ b/internal/ibazel/profiler/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@io_bazel_rules_go//go:def.bzl", "go_embed_data", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 
 go_library(

--- a/internal/ibazel/profiler/profiler.go
+++ b/internal/ibazel/profiler/profiler.go
@@ -16,6 +16,7 @@ package profiler
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -32,6 +33,11 @@ import (
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/third_party/bazel/master/src/main/protobuf/blaze_query"
 )
+
+// ProfilerJs is embedded data.
+//
+//go:embed profiler.js
+var ProfilerJs []byte
 
 var profileDev = flag.String("profile_dev", "", "Turn on profiling and append report to file")
 
@@ -338,7 +344,7 @@ func (i *Profiler) jsHandler(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	rw.Header().Set("Content-Type", "application/javascript")
-	_, err := rw.Write(js)
+	_, err := rw.Write(ProfilerJs)
 	if err != nil {
 		log.Errorf("Error handling profile.js request: %v", err)
 	}


### PR DESCRIPTION
In the upcoming update, '[rules_go](https://github.com/bazelbuild/rules_go/releases)' will no longer include the 'go_embed_data' rule. Instead, this diff modifies 'go_embed_data' to adhere to the recommended approach for embedding data using 'go:embed'.