### PR TITLE
remove log statement for legacy bazel watcher on macOS

### DIFF
--- a/internal/ibazel/fswatcher/factory_darwin.go
+++ b/internal/ibazel/fswatcher/factory_darwin.go
@@ -19,27 +19,16 @@ package fswatcher
 
 import (
 	"os"
-	"sync"
 
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/fswatcher/common"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/fswatcher/fsevents"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/fswatcher/fsnotify"
-	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
 )
-
-var experimentalWatcherLog sync.Once
 
 func NewWatcher() (common.Watcher, error) {
 	flag, ok := os.LookupEnv("IBAZEL_USE_LEGACY_WATCHER")
 	if ok && flag != "0" {
 		return fsnotify.NewWatcher()
-	}
-
-	// Avoid logging if IBAZEL_USE_LEGACY_WATCHER=0
-	if !ok {
-		experimentalWatcherLog.Do(func() {
-			log.Log("You are using an experimental filesystem watcher. If you would like to disable that, please set the environment variable\n\tIBAZEL_USE_LEGACY_WATCHER=1")
-		})
 	}
 
 	return fsevents.NewWatcher()


### PR DESCRIPTION
This fsevents file watcher has been in use for macOS for a long time and can be made default without log spamming. Allow people to still easily drop to the legacy watcher if desired. 