### PR TITLE
support MODULE.bazel file

### DIFF
--- a/internal/ibazel/workspace/workspace.go
+++ b/internal/ibazel/workspace/workspace.go
@@ -59,6 +59,10 @@ func (m *MainWorkspace) FindWorkspace() (string, error) {
 			return path, nil
 		}
 
+		if _, err := os.Stat(filepath.Join(path, "MODULE.bazel")); err == nil {
+			return path, nil
+		}
+
 		// If we've reached the root, then we know the cwd isn't within a workspace
 		if path == volume {
 			return "", errors.New("ibazel was not invoked from within a workspace\n")

--- a/internal/ibazel/workspace/workspace_test.go
+++ b/internal/ibazel/workspace/workspace_test.go
@@ -73,6 +73,14 @@ func TestAppleCaseInsensitivity(t *testing.T) {
 			files:         []string{},
 			err:           false,
 		},
+		"MODULE.bazel": {
+			startingWD:    "",
+			wantPath:      "",
+			dirs:          []string{},
+			workspacePath: "/MODULE.bazel",
+			files:         []string{},
+			err:           false,
+		},
 	}
 
 	startDir, err := os.Getwd()


### PR DESCRIPTION
addresses #646 

 * verified that `ibazel` with this patch can correctly watch and run the target in the linked issue
 * verified that `//internal/ibazel/workspace:workspace_test` passes
