### PR TITLE
support workspace whose path may contain symlinks

### DIFF
--- a/internal/e2e/symlink_dir/BUILD.bazel
+++ b/internal/e2e/symlink_dir/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "symlink_dir_test",
+    srcs = ["symlink_dir_test.go"],
+    deps = [
+        "//internal/e2e",
+        "@io_bazel_rules_go//go/tools/bazel_testing:go_default_library",
+    ],
+)

--- a/internal/e2e/symlink_dir/symlink_dir_test.go
+++ b/internal/e2e/symlink_dir/symlink_dir_test.go
@@ -66,10 +66,10 @@ func TestMain(m *testing.M) {
 	})
 }
 
-// note: an earlier implementation of `ibazel.go` used `os.Getwd` which states
-// "If the current directory can be reached via multiple paths (due to symbolic
+// note: the implementation of `workspace.go` uses `os.Getwd` which states "If
+// the current directory can be reached via multiple paths (due to symbolic
 // links), Getwd may return any one of them." This resulted in inconsistent
-// automatic rebuild behavior.
+// automatic rebuild behavior because `ibazel.go` was not evaluating symlinks.
 func TestSymlinkRun(t *testing.T) {
 	ibazel := e2e.SetUp(t)
 	ibazel.Run([]string{}, "//:simple")

--- a/internal/e2e/symlink_dir/symlink_dir_test.go
+++ b/internal/e2e/symlink_dir/symlink_dir_test.go
@@ -1,0 +1,82 @@
+package symlink_dir
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/bazel-watcher/internal/e2e"
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+// bazel_testing.TestMain automatically creates a `WORKSPACE` file at the root if not provided
+const mainFiles = `
+-- BUILD.bazel --
+sh_binary(
+  name = "simple",
+  srcs = ["simple.sh"],
+)
+
+-- simple.sh --
+printf "Started 1!"
+`
+
+// something
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: mainFiles,
+		SetUp: func() error {
+			// creates a directory `./holder` and symlink
+			// `./holder/symlinked-workspace` pointing to the normal working
+			// directory `./main` created by `bazel_testing.TestMain`
+
+			// create holder directory
+			holder, err := filepath.Abs(filepath.Join("..", "holder"))
+			if err != nil {
+				log.Fatalf("Error determining absolute path: %v", err)
+			}
+
+			if err = os.Mkdir(holder, 0777); err != nil {
+				log.Fatalf("Error making directory: %v", err)
+			}
+
+			// create symlink pointing to the main workspace
+			symlinkWd, err := filepath.Abs(filepath.Join(holder, "symlinked-workspace"))
+			if err != nil {
+				log.Fatalf("Error determining absolute path: %v", err)
+			}
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				log.Fatalf("Error getting working directory: %v", err)
+			}
+
+			if err = os.Symlink(cwd, symlinkWd); err != nil {
+				log.Fatalf("Error creating symlink: %v", err)
+			}
+
+			// chdir via the symlink
+			if err = os.Chdir(symlinkWd); err != nil {
+				log.Fatalf("Error changing directory: %v", err)
+			}
+
+			return err
+		},
+	})
+}
+
+// note: an earlier implementation of `ibazel.go` used `os.Getwd` which states
+// "If the current directory can be reached via multiple paths (due to symbolic
+// links), Getwd may return any one of them." This resulted in inconsistent
+// automatic rebuild behavior.
+func TestSymlinkRun(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	ibazel.Run([]string{}, "//:simple")
+	defer ibazel.Kill()
+
+	ibazel.ExpectOutput("Started 1!")
+
+	e2e.MustWriteFile(t, "simple.sh", `printf "Started 2!"`)
+	ibazel.ExpectOutput("Started 2!")
+}

--- a/internal/e2e/symlink_dir/symlink_dir_test.go
+++ b/internal/e2e/symlink_dir/symlink_dir_test.go
@@ -22,7 +22,6 @@ sh_binary(
 printf "Started 1!"
 `
 
-// something
 func TestMain(m *testing.M) {
 	bazel_testing.TestMain(m, bazel_testing.Args{
 		Main: mainFiles,

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -541,11 +541,17 @@ func (i *IBazel) watchFiles(query string, watcher common.Watcher) {
 	uniqueDirectories := map[string]struct{}{}
 
 	for _, file := range toWatch {
-		if _, err := os.Stat(file); !os.IsNotExist(err) {
-			filesWatched[file] = struct{}{}
+		path, err := filepath.EvalSymlinks(file)
+		if err != nil {
+			log.Errorf("Error evaluating symbolic links for source file: %v", err)
+			return
 		}
 
-		parentDirectory, _ := filepath.Split(file)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			filesWatched[path] = struct{}{}
+		}
+
+		parentDirectory, _ := filepath.Split(path)
 		// Add a watch to the file's parent directory, we might already have this dir in our set but thats OK
 		uniqueDirectories[parentDirectory] = struct{}{}
 	}


### PR DESCRIPTION
addresses #649 

 * creates new test `symlink_dir_test.go`. note that I am not really happy with this test because `os.Chdir` appears to resolve the symlink itself—I'm open to suggestions here
 * all existing tests pass _except_ `//internal/e2e/many_dirs:many_dirs` which didn't pass on my machine even before these changes