### PR TITLE
partially call `bazel info` to skip cache eviction

### DIFF
--- a/internal/bazel/testing/mock.go
+++ b/internal/bazel/testing/mock.go
@@ -61,6 +61,10 @@ func (b *MockBazel) Info() (map[string]string, error) {
 	b.actions = append(b.actions, []string{"Info"})
 	return map[string]string{}, nil
 }
+func (b *MockBazel) InfoCommand(args ...string) ([]string, error) {
+	b.actions = append(b.actions, append([]string{"InfoCommand"}, args...))
+	return []string{}, nil
+}
 func (b *MockBazel) AddQueryResponse(query string, res *blaze_query.QueryResult) {
 	if b.queryResponse == nil {
 		b.queryResponse = map[string]*blaze_query.QueryResult{}

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -114,9 +114,8 @@ func New(version string) (*IBazel, error) {
 		lifecycleHooks,
 	}
 
-	info, _ := i.getInfo()
 	for _, l := range i.lifecycleListeners {
-		l.Initialize(&info)
+		l.Initialize(i.getInfo)
 	}
 
 	go func() {
@@ -472,6 +471,18 @@ func (i *IBazel) getInfo() (map[string]string, error) {
 	b := i.newBazel()
 
 	res, err := b.Info()
+	if err != nil {
+		log.Errorf("Error getting Bazel info %v", err)
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (i *IBazel) getInfoByKeys(keys ...string) ([]string, error) {
+	b := i.newBazel()
+
+	res, err := b.InfoCommand(keys...)
 	if err != nil {
 		log.Errorf("Error getting Bazel info %v", err)
 		return nil, err

--- a/internal/ibazel/ibazel_unix.go
+++ b/internal/ibazel/ibazel_unix.go
@@ -18,7 +18,6 @@
 package ibazel
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -28,17 +27,14 @@ import (
 )
 
 func (i *IBazel) realLocalRepositoryPaths() (map[string]string, error) {
-	info, err := i.getInfo()
-	if err != nil {
-		log.Errorf("Error finding bazel info: %v\n", err)
+	info, err := i.getInfoByKeys("output_base", "install_base")
+	if err != nil || info == nil {
+		log.Errorf("Error finding bazel info output_base install_base: %v\n", err)
 		return nil, err
 	}
 
-	outputBase := info["output_base"]
-	installBase := info["install_base"]
-	if false {
-		return nil, fmt.Errorf("`bazel info` didn't include install_base")
-	}
+	outputBase, installBase := info[0], info[1]
+
 	externalPath := filepath.Join(outputBase, "external")
 
 	files, err := ioutil.ReadDir(externalPath)

--- a/internal/ibazel/lifecycle.go
+++ b/internal/ibazel/lifecycle.go
@@ -11,7 +11,7 @@ import (
 type Lifecycle interface {
 	// Initialize is called once it is known that this lifecycle client is going
 	// to be used.
-	Initialize(info *map[string]string)
+	Initialize(func() (map[string]string, error))
 
 	// TargetDecider takes a protobuf rule and performs setup if it matches the
 	// listener's expectations.

--- a/internal/ibazel/lifecycle_hooks/lifecycle_hooks.go
+++ b/internal/ibazel/lifecycle_hooks/lifecycle_hooks.go
@@ -43,7 +43,7 @@ func New() *LifecycleHooks {
 	}
 }
 
-func (l *LifecycleHooks) Initialize(info *map[string]string) {}
+func (l *LifecycleHooks) Initialize(func() (map[string]string, error)) {}
 
 func (l *LifecycleHooks) TargetDecider(rule *blaze_query.Rule) {}
 

--- a/internal/ibazel/live_reload/server.go
+++ b/internal/ibazel/live_reload/server.go
@@ -47,7 +47,7 @@ func (l *LiveReloadServer) AddEventsListener(listener Events) {
 	l.eventListeners = append(l.eventListeners, listener)
 }
 
-func (l *LiveReloadServer) Initialize(info *map[string]string) {}
+func (l *LiveReloadServer) Initialize(func() (map[string]string, error)) {}
 
 func (l *LiveReloadServer) Cleanup() {
 	if l.lrserver != nil {

--- a/internal/ibazel/output_runner/output_runner.go
+++ b/internal/ibazel/output_runner/output_runner.go
@@ -64,7 +64,7 @@ func New() *OutputRunner {
 	return i
 }
 
-func (i *OutputRunner) Initialize(info *map[string]string) {}
+func (i *OutputRunner) Initialize(func() (map[string]string, error)) {}
 
 func (i *OutputRunner) TargetDecider(rule *blaze_query.Rule) {}
 

--- a/internal/ibazel/profiler/profiler.go
+++ b/internal/ibazel/profiler/profiler.go
@@ -100,7 +100,7 @@ func New(version string) *Profiler {
 	return p
 }
 
-func (i *Profiler) Initialize(info *map[string]string) {
+func (i *Profiler) Initialize(getInfo func() (map[string]string, error)) {
 	if *profileDev == "" {
 		return
 	}
@@ -114,9 +114,15 @@ func (i *Profiler) Initialize(info *map[string]string) {
 
 	log.Errorf("Profile output: %s", *profileDev)
 
+	info, err := getInfo()
+	if err != nil {
+		log.Errorf("Failed to get info: %v", err)
+		return
+	}
+
 	i.iterationBuildStart = true
 	i.newIteration()
-	i.startEvent(info)
+	i.startEvent(&info)
 	i.startProfilerServer()
 }
 


### PR DESCRIPTION
Found out `bazel info` partially evict cache.

There is issue I created in bazel repo.
https://github.com/bazelbuild/bazel/issues/22360#issuecomment-2110447530

For me and my internal project, changing from: `bazel info` -> `bazel info output_base install_base` fixes eviction problem. 

So `ibazel` starts faster.