### PR TITLE
feat: detect bzlmod files identifying workspace directory

### DIFF
--- a/internal/ibazel/workspace/workspace_test.go
+++ b/internal/ibazel/workspace/workspace_test.go
@@ -71,7 +71,7 @@ func TestAppleCaseInsensitivity(t *testing.T) {
 		},
 		"no workspace in workspace-named path": {
 			startingWD: "c/WORKSPACE",
-			wantPath:   "/a",
+			wantPath:   filepath.FromSlash("/a"),
 			dirs: []string{
 				"a/b",
 				"c/WORKSPACE",
@@ -97,7 +97,7 @@ func TestAppleCaseInsensitivity(t *testing.T) {
 			// the "WORKSPACE" dirname should not early-quit the search, allowing
 			// us to find /c/MODULE.bazel
 			startingWD: "c/d/WORKSPACE",
-			wantPath:   "/c",
+			wantPath:   filepath.FromSlash("/c"),
 			dirs: []string{
 				"a/b",
 				"c/d/WORKSPACE",

--- a/internal/ibazel/workspace/workspace_test.go
+++ b/internal/ibazel/workspace/workspace_test.go
@@ -42,6 +42,22 @@ func TestAppleCaseInsensitivity(t *testing.T) {
 			files:         []string{},
 			err:           false,
 		},
+		"simple with bzlmod extension": {
+			startingWD:    "",
+			wantPath:      "",
+			dirs:          []string{},
+			workspacePath: "/WORKSPACE.bzlmod",
+			files:         []string{},
+			err:           false,
+		},
+		"simple with MODULE.bazel": {
+			startingWD:    "",
+			wantPath:      "",
+			dirs:          []string{},
+			workspacePath: "/MODULE.bazel",
+			files:         []string{},
+			err:           false,
+		},
 		"no workspace": {
 			startingWD: "c/d",
 			wantPath:   "",
@@ -52,6 +68,43 @@ func TestAppleCaseInsensitivity(t *testing.T) {
 			workspacePath: "/a/WORKSPACE",
 			files:         []string{},
 			err:           true,
+		},
+		"no workspace in workspace-named path": {
+			startingWD: "c/WORKSPACE",
+			wantPath:   "/a",
+			dirs: []string{
+				"a/b",
+				"c/WORKSPACE",
+			},
+			workspacePath: "/a/WORKSPACE",
+			files:         []string{},
+			err:           true,
+		},
+		"no workspace in MODULE.bazel-named path": {
+			startingWD: "c/MODULE.bazel",
+			wantPath:   "",
+			dirs: []string{
+				"a/b",
+				"c/MODULE.bazel",
+			},
+			workspacePath: "/a/WORKSPACE",
+			files:         []string{},
+			err:           true,
+		},
+		"workspace nested in workspace-named path": {
+			// this is intended to catch case-insensitive Macs but mimics the
+			// case-insensitive match with a case-sensitive match of the dir
+			// the "WORKSPACE" dirname should not early-quit the search, allowing
+			// us to find /c/MODULE.bazel
+			startingWD: "c/d/WORKSPACE",
+			wantPath:   "/c",
+			dirs: []string{
+				"a/b",
+				"c/d/WORKSPACE",
+			},
+			workspacePath: "/c/MODULE.bazel",
+			files:         []string{},
+			err:           false,
 		},
 		"nested workspace": {
 			startingWD: "a/workspace",


### PR DESCRIPTION
In #683 `ibazel` cannot find a workspace by `WORKSPACE.bzlmod`
In my own work, `ibazel` cannot find the workspace by `MODULE.bazel`

Generally, the workaround has been to create an empty file `WORKSPACE.bazel` (which appeared with #536, shipped in v0.25.3) to help `ibazel` but this is likely not the expected behaviour.

Solution is proposed in this PR:
- looks for `WORKSPACE.bzlmod`, `WORKSPACE.bazel`, `MODULE.bazel`, falling back to `WORKSPACE`
- unittests for all four
- preserves the `IsDir()` check to protect against directories in path matching case-insensitive to these names
- adds the `WORKSPACE.bazel` (#536) to the same case-insensitive-aware check and treats consistently to the other files
- unittest for case-insensitive-matching directory: ignoring directory-matches in general

This solution is broader than proposed by @austinwoon (#684) -- but I only saw #684 after solving my own pain for myself.  I would prefer @austinwoon be recognized for their contribution; I will happily rebase on #684 if it helps establish austinwoon in the contribution path.

## Test
A simple test can be down with `rules_gazebo`, a small-ish ruleset that has workarounds:
0. assuming you're working in $HOME/src
1. `(cd ~/src && git clone git@github.com:bazelbuild/bazel-watcher.git)`
2. `(cd ~/src && git clone https://github.com/gazebosim/rules_gazebo)`
3. `(cd ~/src/bazel-watcher && bazel build //cmd/ibazel)`
4. `sudo install -m0755 ~/src/bazel-watcher/bazel-bin/cmd/ibazel/ibazel_/ibazel /usr/local/bin/` (assuming it's on your `$PATH`)
5. `(cd ~/src/rules_gazebo && ibazel build //...)` -- we expect the workarounds to allow this to work
6. `rm -f ~/src/rules_gazebo/WORKSPACE.b*` -- delete the workarounds
7. `(cd ~/src/rules_gazebo && ibazel build //...)` -- repaired `ibazel` still works here (due to `MODULE.bazel`)