### PR TITLE
fix: support for bzlmod in FindWorkspace

### DIFF
--- a/internal/ibazel/workspace/workspace.go
+++ b/internal/ibazel/workspace/workspace.go
@@ -59,6 +59,10 @@ func (m *MainWorkspace) FindWorkspace() (string, error) {
 			return path, nil
 		}
 
+		if _, err := os.Stat(filepath.Join(path, "MODULE.bazel")); err == nil {
+			return path, nil
+		}
+
 		// If we've reached the root, then we know the cwd isn't within a workspace
 		if path == volume {
 			return "", errors.New("ibazel was not invoked from within a workspace\n")


### PR DESCRIPTION
- `ibazel` uses the `WORKSPACE` / `WORKSPACE.bazel` file to detect the workspace root
- This doesn't work for bzlmod workspaces (which is the default in newer versions of Bazel)
- We now also detect the workspace root using the presence of the `MODULE.bazel` file
-  Closes #682