### PR TITLE
Download outputs when running in notify mode

### DIFF
--- a/internal/ibazel/command/notify_command.go
+++ b/internal/ibazel/command/notify_command.go
@@ -94,7 +94,8 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 func (c *notifyCommand) NotifyOfChanges() *bytes.Buffer {
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
-	b.SetArguments(c.bazelArgs)
+	// We must always pass --remote_download_outputs=toplevel to ensure that the runfiles of the target are correctly downloaded before we notify the process
+	b.SetArguments(append(c.bazelArgs, "--remote_download_outputs=toplevel"))
 
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)

--- a/internal/ibazel/command/notify_command_test.go
+++ b/internal/ibazel/command/notify_command_test.go
@@ -60,7 +60,7 @@ func TestNotifyCommand(t *testing.T) {
 
 	b.AssertActions(t, [][]string{
 		{"SetStartupArgs"},
-		{"SetArguments"},
+		{"SetArguments", "--remote_download_outputs=toplevel"},
 		{"WriteToStderr", "true"},
 		{"WriteToStdout", "true"},
 		{"Build", "//path/to:target"},
@@ -70,12 +70,12 @@ func TestNotifyCommand(t *testing.T) {
 		{"WriteToStdout", "true"},
 		{"Run", "--script_path=.*", "//path/to:target"},
 		{"SetStartupArgs"},
-		{"SetArguments"},
+		{"SetArguments", "--remote_download_outputs=toplevel"},
 		{"WriteToStderr", "true"},
 		{"WriteToStdout", "true"},
 		{"Build", "//path/to:target"},
 		{"SetStartupArgs"},
-		{"SetArguments"},
+		{"SetArguments", "--remote_download_outputs=toplevel"},
 		{"WriteToStderr", "true"},
 		{"WriteToStdout", "true"},
 		{"Build", "//path/to:target"},


### PR DESCRIPTION
If `--remote_download_outputs=minimal` is set, there is currently no good way to use an `ibazel_notify_changes` `run` target.

Alternative I considered: set an environment variable when invoking `bazel` from `ibazel`, and allow consumers to use a bazel wrapper to only set `--remote_download_outputs=minimal` when not being run from ibazel.  The committed solution seems better than this because it requires less setup from the end user.

This is a breaking change, because if a target previously relied on `--remote_download_outputs=all`, then this will break that expectation.

I'm willing to be told that this change is a bad idea, and I will just add it to our fork, but I thought I would send it here too.