### PR TITLE
Add BES flags --bes_backend and --bes_keywords to overrideable flags.

### DIFF
--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -507,7 +507,7 @@ func (i *IBazel) queryForSourceFiles(query string) ([]string, error) {
 			label := target.GetSourceFile().GetName()
 			if strings.HasPrefix(label, "@") {
 				repo, target := parseTarget(label)
-				if realPath, ok := findInLocalRepository(localRepositories, repo); ok {
+				if realPath, ok := localRepositories[repo]; ok {
 					label = strings.Replace(target, ":", string(filepath.Separator), 1)
 					toWatch = append(toWatch, filepath.Join(realPath, label))
 					break
@@ -603,14 +603,3 @@ func keys(m map[string]struct{}) []string {
 	}
 	return keys
 }
-
-func findInLocalRepository(localRepositories map[string]string, repo string) (string, bool) {
-	if realPath, ok := localRepositories[repo]; ok {
-		return realPath, ok
-	}
-	if realPath, ok := localRepositories[repo + "+"]; ok {
-		return realPath, ok
-	}
-	return "", false
-}
-


### PR DESCRIPTION
Support setting bazel flags relevant to BES.

This allows build results to be propagated to external tools instead of relying on parsing bazel-watcher outputs.

[BES flags](https://bazel.build/remote/bep#bes-flags)