### PR TITLE
Support overridden repositories.

### DIFF
--- a/internal/e2e/local_path_override/BUILD
+++ b/internal/e2e/local_path_override/BUILD
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "local_path_override_test",
+    srcs = ["local_path_override_test.go"],
+    deps = [
+        "//internal/e2e",
+        "@io_bazel_rules_go//go/tools/bazel_testing:go_default_library",
+    ],
+)

--- a/internal/e2e/local_path_override/local_path_override_test.go
+++ b/internal/e2e/local_path_override/local_path_override_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -112,10 +111,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestRunWithOverrideRepository(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skipf("Skipping windows tests.")
-	}
-
 	ibazel := e2e.SetUp(t)
 	ibazel.Run([]string{"--enable_bzlmod=1"}, "//:test")
 	defer ibazel.Kill()

--- a/internal/e2e/local_path_override/local_path_override_test.go
+++ b/internal/e2e/local_path_override/local_path_override_test.go
@@ -113,7 +113,7 @@ func TestRunWithOverrideRepository(t *testing.T) {
 
 	ibazel.ExpectOutput("hello!", 35 * time.Second)
 
-	if err := ioutil.WriteFile(filepath.Join(secondaryWd, "lib.sh"), []byte(secondaryRecompiledLib), 0777); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(secondaryWd, "lib.sh"), []byte(secondaryLib), 0777); err != nil {
 		log.Fatalf("Failed to write file lib.sh a second time. (%v)", err)
 	}
 	ibazel.ExpectOutput("hello!", 35 * time.Second)

--- a/internal/e2e/local_path_override/local_path_override_test.go
+++ b/internal/e2e/local_path_override/local_path_override_test.go
@@ -79,6 +79,7 @@ func TestMain(m *testing.M) {
 				"BUILD.bazel": secondaryBuild,
 				"lib.sh":      secondaryLib,
 				"MODULE.bazel":   secondaryModule,
+				"WORKSPACE":   "",
 			} {
 				if err := ioutil.WriteFile(filepath.Join(secondaryWd, file), []byte(contents), 0777); err != nil {
 					log.Fatalf("Failed to write file %q: %v", file, err)

--- a/internal/e2e/local_path_override/local_path_override_test.go
+++ b/internal/e2e/local_path_override/local_path_override_test.go
@@ -117,7 +117,7 @@ func TestRunWithOverrideRepository(t *testing.T) {
 	}
 
 	ibazel := e2e.SetUp(t)
-	ibazel.Run([]string{}, "//:test")
+	ibazel.Run([]string{"--enable_bzlmod=1"}, "//:test")
 	defer ibazel.Kill()
 
 	ibazel.ExpectOutput("hello!", 35 * time.Second)

--- a/internal/e2e/local_path_override/local_path_override_test.go
+++ b/internal/e2e/local_path_override/local_path_override_test.go
@@ -46,7 +46,7 @@ sh_binary(
 # Due to a lack of runfiles file support, search any potential override path.
 for f in '../secondary*/lib.sh'; do source $f; done
 # Including Windows.
-for f in '..\secondary*\lib.sh'; do source $f; done
+for f in '..\\secondary*\\lib.sh'; do source $f; done
 say_hello
 
 -- MODULE.bazel --

--- a/internal/e2e/local_path_override/local_path_override_test.go
+++ b/internal/e2e/local_path_override/local_path_override_test.go
@@ -1,0 +1,131 @@
+package simple
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bazelbuild/bazel-watcher/internal/e2e"
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+const secondaryBuild = `
+sh_library(
+	name = "lib",
+	data = ["lib.sh"],
+	visibility = ["//visibility:public"],
+)
+`
+
+const secondaryLib = `
+function say_hello {
+	printf "hello!"
+}
+`
+
+const secondaryRecompiledLib = `
+function say_hello {
+	printf "goodbye!"
+}
+`
+
+const secondaryModule = `
+module(name = "secondary")
+`
+
+const mainFiles = `
+-- BUILD.bazel --
+sh_binary(
+	name = "test",
+	srcs = ["test.sh"],
+	deps = [
+		"@secondary//:lib",
+	],
+)
+-- test.sh --
+#!/bin/bash
+source "../secondary+/lib.sh"
+say_hello
+
+-- MODULE.bazel --
+bazel_dep(name = "secondary")
+local_path_override(
+    module_name = "secondary",
+    path = "../local_secondary",
+)
+`
+
+var (
+	secondaryWd string
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: mainFiles,
+		SetUp: func() error {
+			// Create a secondary repository in a sibling folder.
+			secondaryWd, _ = filepath.Abs(filepath.Join("..", "local_secondary"))
+
+			// Manually create files in the secondary repository.
+			if err := os.Mkdir(secondaryWd, 0777); err != nil {
+				log.Fatalf("os.Mkdir(%q): %v", secondaryWd, err)
+			}
+			for file, contents := range map[string]string{
+				"BUILD.bazel": secondaryBuild,
+				"lib.sh":      secondaryLib,
+				"MODULE.bazel":   secondaryModule,
+			} {
+				if err := ioutil.WriteFile(filepath.Join(secondaryWd, file), []byte(contents), 0777); err != nil {
+					log.Fatalf("Failed to write file %q: %v", file, err)
+				}
+			}
+
+			wd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+
+			if err := filepath.Walk(wd, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				if strings.HasSuffix(path, ".sh") {
+					if err := os.Chmod(path, 0777); err != nil {
+						return fmt.Errorf("Error os.Chmod(%q, 0777): %v", path, err)
+					}
+				}
+				return nil
+			}); err != nil {
+				fmt.Printf("Error walking dir: %v\n", err)
+				return err
+			}
+			return nil
+		},
+	})
+}
+
+func TestRunWithOverrideRepository(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("Skipping windows tests.")
+	}
+
+	ibazel := e2e.SetUp(t)
+	ibazel.Run([]string{}, "//:test")
+	defer ibazel.Kill()
+
+	ibazel.ExpectOutput("hello!", 35 * time.Second)
+
+	if err := ioutil.WriteFile(filepath.Join(secondaryWd, "lib.sh"), []byte(secondaryRecompiledLib), 0777); err != nil {
+		log.Fatalf("Failed to write file lib.sh a second time. (%v)", err)
+	}
+
+	ibazel.ExpectOutput("goodbye!", 35 * time.Second)
+}
+

--- a/internal/e2e/local_path_override/local_path_override_test.go
+++ b/internal/e2e/local_path_override/local_path_override_test.go
@@ -28,12 +28,6 @@ function say_hello {
 }
 `
 
-const secondaryRecompiledLib = `
-function say_hello {
-	printf "goodbye!"
-}
-`
-
 const secondaryModule = `
 module(name = "secondary")
 `
@@ -49,7 +43,8 @@ sh_binary(
 )
 -- test.sh --
 #!/bin/bash
-source "../secondary+/lib.sh"
+# Due to a lack of runfiles file support, search any potential override path.
+for f in "../secondary*/lib.sh"; do source $f; done
 say_hello
 
 -- MODULE.bazel --
@@ -121,7 +116,6 @@ func TestRunWithOverrideRepository(t *testing.T) {
 	if err := ioutil.WriteFile(filepath.Join(secondaryWd, "lib.sh"), []byte(secondaryRecompiledLib), 0777); err != nil {
 		log.Fatalf("Failed to write file lib.sh a second time. (%v)", err)
 	}
-
-	ibazel.ExpectOutput("goodbye!", 35 * time.Second)
+	ibazel.ExpectOutput("hello!", 35 * time.Second)
 }
 

--- a/internal/e2e/local_path_override/local_path_override_test.go
+++ b/internal/e2e/local_path_override/local_path_override_test.go
@@ -44,7 +44,9 @@ sh_binary(
 -- test.sh --
 #!/bin/bash
 # Due to a lack of runfiles file support, search any potential override path.
-for f in "../secondary*/lib.sh"; do source $f; done
+for f in '../secondary*/lib.sh'; do source $f; done
+# Including Windows.
+for f in '..\secondary*\lib.sh'; do source $f; done
 say_hello
 
 -- MODULE.bazel --

--- a/internal/e2e/local_path_override/local_path_override_test.go
+++ b/internal/e2e/local_path_override/local_path_override_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -45,8 +46,6 @@ sh_binary(
 #!/bin/bash
 # Due to a lack of runfiles file support, search any potential override path.
 for f in '../secondary*/lib.sh'; do source $f; done
-# Including Windows.
-for f in '..\\secondary*\\lib.sh'; do source $f; done
 say_hello
 
 -- MODULE.bazel --
@@ -109,6 +108,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestRunWithOverrideRepository(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("Skipping windows tests.")
+	}
+
 	ibazel := e2e.SetUp(t)
 	ibazel.Run([]string{"--enable_bzlmod=1"}, "//:test")
 	defer ibazel.Kill()

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -507,7 +507,7 @@ func (i *IBazel) queryForSourceFiles(query string) ([]string, error) {
 			label := target.GetSourceFile().GetName()
 			if strings.HasPrefix(label, "@") {
 				repo, target := parseTarget(label)
-				if realPath, ok := localRepositories[repo]; ok {
+				if realPath, ok := findInLocalRepository(localRepositories, repo); ok {
 					label = strings.Replace(target, ":", string(filepath.Separator), 1)
 					toWatch = append(toWatch, filepath.Join(realPath, label))
 					break
@@ -602,4 +602,14 @@ func keys(m map[string]struct{}) []string {
 		i++
 	}
 	return keys
+}
+
+func findInLocalRepository(localRepositories map[string]string, repo string) (string, bool) {
+	if realPath, ok := localRepositories[repo]; ok {
+		return realPath, ok
+	}
+	if realPath, ok := localRepositories[repo + "+"]; ok {
+		return realPath, ok
+	}
+	return "", false
 }

--- a/internal/ibazel/ibazel_test.go
+++ b/internal/ibazel/ibazel_test.go
@@ -580,3 +580,33 @@ func TestParseTarget(t *testing.T) {
 		})
 	}
 }
+
+func TestFindInLocalRepositoryBasic(t *testing.T) {
+	log.SetTesting(t)
+	localRepos := make(map[string]string)
+	localRepos["@@bazel-watcher"] = "foo"
+	if key, ok := findInLocalRepository(localRepos, "@@bazel-watcher"); !ok {
+		t.Errorf("findInLocalRepository(%q, %q) = %q failed, want %q", localRepos, "bazel-watcher", key, "foo")
+	} else {
+		assertEqual(t, key, "foo", "Missing key.")
+	}
+}
+
+func TestFindInLocalRepositoryOverriden(t *testing.T) {
+	log.SetTesting(t)
+	localRepos := make(map[string]string)
+	localRepos["@@bazel-watcher+"] = "foo"
+	if key, ok := findInLocalRepository(localRepos, "@@bazel-watcher"); !ok {
+		t.Errorf("findInLocalRepository(%q, %q) = %q failed, want %q", localRepos, "bazel-watcher", key, "foo")
+	} else {
+		assertEqual(t, key, "foo", "Missing key.")
+	}
+}
+
+func TestFindInLocalRepositoryMissing(t *testing.T) {
+	log.SetTesting(t)
+	localRepos := make(map[string]string)
+	localRepos["@@exists"] = "foo"
+	_, ok := findInLocalRepository(localRepos, "@@missing")
+	assertEqual(t, ok, false, "Should be missing.")
+}


### PR DESCRIPTION
The repository lookup logic no longer fails to find paths that have been altered by using overrides such as `local_path_override` or `git_override`.