### PR TITLE
Support overriding  --test_sharding_strategy

### DIFF
--- a/cmd/ibazel/main.go
+++ b/cmd/ibazel/main.go
@@ -81,6 +81,7 @@ var overrideableBazelFlags []string = []string{
 	"--test_output=",
 	"--test_tag_filters=",
 	"--test_timeout=",
+	"--test_sharding_strategy=",
 	"--test_summary=",
 	// Custom Starlark build settings
 	// https://docs.bazel.build/versions/master/skylark/config.html#using-build-settings-on-the-command-line


### PR DESCRIPTION
In the event you want to watch a test target that is sharded, allow the end user to disable sharding so the target can be watched