### PR TITLE
Fix notify_command.go to pass `args`allowing `--test_sharding_strategy=disabled` with `--`

### DIFF
--- a/internal/ibazel/command/notify_command.go
+++ b/internal/ibazel/command/notify_command.go
@@ -66,6 +66,8 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)
+	// For commands like `--test_sharding_strategy=disabled` which come through normal args
+	b.SetArguments(c.args)
 
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)


### PR DESCRIPTION
Fixes a bug introduced by #744 where on bazel run with sharding enabled the process would fail to launch. this also requires the user to use the `--` attribute before passing the flag so it gets sorted into args.

If this is not passed, the CLI will not discern between bazelArgs and args that come after `--`. Once this is landed, you can test a target with sharding so long as you do `ibazel run //path/to/target:test --` and then whatever flags you want. 