### PR TITLE
Fix building release binary for darwin_amd64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
 
           - name: darwin_amd64
             artifact: ibazel_darwin_amd64
-            os: macos-latest
+            os: macos-13
             build_flags: --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64_cgo
             # See comment below for more information on this flag.
             cpu_flag: --cpu=darwin_amd64


### PR DESCRIPTION
Running the release job on macos-latest is using darwin_arm64, so cross compiling the
binary to darwin_amd64.

To make this work, either the build needs to run under Rosetta (effectively not cross compiling), or the build needs a
C cross compiler targetting darwin_amd64 (otherwise CGO is disabled).

Using the macos-13 runner fixes this problem by avoiding to cross compile.
