### PR TITLE
Fix publishing npm release (hopefully)

### DIFF
--- a/release/npm/generate_package.go
+++ b/release/npm/generate_package.go
@@ -14,7 +14,7 @@ type jsPackage struct {
 	Bin           map[string]string `json:"bin"`
 	Contributors  []string          `json:"contributors"`
 	License       string            `json:"license"`
-	PublishConfig map[string]string `json:"publish_config"`
+	PublishConfig map[string]string `json:"publishConfig"`
 }
 
 // Note that Version must be assigned to a constant value to allow stamping to


### PR DESCRIPTION
- **npm: Strip `v` prefix from version tag when publishing**
- **npm: Fix publishing to registry**

> If your npm package uses a scope prefix and the package is public, you need to use the option npm publish --access public. This is an option that npm requires to prevent someone from publishing a private package unintentionally.

For a npm publish dry-run, it was using the right access mode:
```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
```
@achew22 I hope this fixes the problem... :crossed_fingers: 