### PR TITLE
npm: Strip `V` prefix from version tag when publishing

### DIFF
--- a/release/npm/generate_package.go
+++ b/release/npm/generate_package.go
@@ -31,7 +31,7 @@ func main() {
 
 	pkg := jsPackage{
 		Name:        "@bazel/ibazel",
-		Version:     strings.TrimPrefix(Version, "v"),
+		Version:     strings.TrimPrefix(strings.TrimPrefix(Version, "v"), "V"),
 		Description: "node distribution of ibazel",
 		Bin: map[string]string{
 			"ibazel": "index.js",


### PR DESCRIPTION
Sometimes releases are tagged with a capital `v`, so take care of that too.
