### PR TITLE
fix not watching files in bazel 8

### DIFF
--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -544,7 +544,7 @@ func (i *IBazel) watchFiles(query string, watcher common.Watcher) {
 		path, err := filepath.EvalSymlinks(file)
 		if err != nil {
 			log.Errorf("Error evaluating symbolic links for source file: %v", err)
-			return
+			continue
 		}
 
 		if _, err := os.Stat(path); !os.IsNotExist(err) {


### PR DESCRIPTION
I updated our repository from bazel 7 to bazel 8.4.2. I switched from `WORKSPACE` to `MODULE.bazel` in the process, maybe it has something to do with that.

Two things were problematic:

## `bazel query(deps(...))`:
`bazel query(deps(...))` fails to lookup stuff that is not necessary for `bazel build` of the project. Something similar to https://github.com/protocolbuffers/protobuf/issues/22386, but not fixed yet. It was a dev_dependency to pip dependencies, which are relevant to `bazel query` but not to `bazel build`, `bazel test` and stuff. So i did not notice it at first.

This breaks the lookup for relevant sources in `ibazel`. I tried to add `--keep_going` and `bazel cquery(deps(...))`. The `bazel cquery` seem to already be somehow relevant in ibazel as well, but I could not get it to work.

I just "fixed" it by adding all the dependencies I don't actually use. Maybe better anyway so that `bazel query` also works for other use cases.

## invalid symlinks:
ibazel somehow feels to access files that are not there:
```
$ ibazel build src/libs/grpc/...

################################################################################
# Did you know iBazel can invoke programs like Gazelle, buildozer, and         #
# other BUILD file generators for you automatically based on bazel output?     #
# Documentation at: https://github.com/bazelbuild/bazel-watcher#output-runner  #
################################################################################

iBazel [8:51PM]: using default bazel_fix_commands
iBazel [8:51PM]: sifting output: Extracting Bazel installation...
Starting local Bazel server (8.4.1) and connecting to it...
INFO: Invocation ID: 8a26b487-f7f2-4442-b9f6-4b3dea2af19f

iBazel [8:51PM]: using 0 matching commandlines
iBazel [8:51PM]: Querying for files to watch...
INFO: Invocation ID: 4f55b5d9-59f2-42c5-bba2-e1fc2320347c
Loading: 0 packages loaded
Loading: 137 packages loaded
    currently loading: @@+_repo_rules2+boost// ... (35 packages)

iBazel [8:51PM]: Error evaluating symbolic links for source file: lstat /home/adrian/deps/grpc/third_party/protobuf/bazel/visibility.bzl: no such file or directory
...
```

My suspicion is that it has something to do with me overriding indirect `bazel_dep(...)` dependencies with `local_path_override(...)`. I am quite sure it is standard practise to do that.

I don't know the codebase very well so I could not dig into the core issue here. I must have something to do with how ibazel finds out which source files are relevant to certain targets. In this case, it happens for external sources, so they are not that relevant for my local development. But the problem is, that as soon as one source file can not be found, the whole target will not be rebuilt on change by ibazel.

*This MR* changes that finding a non existing file is no longer a hard error which results in aborting the search for more relevant source files. I think this is sensible even when there are real bugs as they might be caused by intermediate changes to the source tree as well.

I have the change in production at my workplace and we are very happy with it, despite printing out dozens of non-found source files :). At least we can work.