### PR TITLE
Fix notify_command.go to pass argsallowing --test_sharding_strategy=disabled with --

### DIFF
--- a/internal/ibazel/command/notify_command.go
+++ b/internal/ibazel/command/notify_command.go
@@ -66,6 +66,8 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)
+	// For commands like `--test_sharding_strategy=disabled` which come through normal args
+	b.SetArguments(c.args)
 
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)

--- a/internal/ibazel/command/notify_command_test.go
+++ b/internal/ibazel/command/notify_command_test.go
@@ -65,7 +65,7 @@ func TestNotifyCommand(t *testing.T) {
 		{"WriteToStdout", "true"},
 		{"Norun", "//path/to:target"},
 		{"SetStartupArgs"},
-		{"SetArguments"},
+		{"SetArguments", "moo"},
 		{"WriteToStderr", "true"},
 		{"WriteToStdout", "true"},
 		{"Run", "--script_path=.*", "//path/to:target"},

--- a/internal/ibazel/command/notify_command_test.go
+++ b/internal/ibazel/command/notify_command_test.go
@@ -65,6 +65,7 @@ func TestNotifyCommand(t *testing.T) {
 		{"WriteToStdout", "true"},
 		{"Norun", "//path/to:target"},
 		{"SetStartupArgs"},
+		{"SetArguments"},
 		{"SetArguments", "moo"},
 		{"WriteToStderr", "true"},
 		{"WriteToStdout", "true"},
@@ -81,6 +82,40 @@ func TestNotifyCommand(t *testing.T) {
 		{"Norun", "//path/to:target"},
 		{"SetStartupArgs"},
 		{"SetArguments"},
+		{"SetArguments", "moo"},
+		{"WriteToStderr", "true"},
+		{"WriteToStdout", "true"},
+		{"Run", "--script_path=.*", "//path/to:target"},
+	})
+}
+
+func TestNotifyCommand_Start_ForwardsArgsToBazel(t *testing.T) {
+	log.SetLogger(t)
+
+	execCommand = func(name string, args ...string) process_group.ProcessGroup {
+		return oldExecCommand("ls")
+	}
+	defer func() { execCommand = oldExecCommand }()
+
+	b := &mock_bazel.MockBazel{}
+	bazelNew = func() bazel.Bazel { return b }
+	defer func() { bazelNew = oldBazelNew }()
+
+	c := &notifyCommand{
+		args:      []string{"--test_sharding_strategy=disabled"},
+		bazelArgs: []string{},
+		target:    "//path/to:target",
+	}
+
+	// Regression test: args after `--` must be forwarded to Bazel in Start().
+	if _, err := c.Start(); err != nil {
+		t.Fatalf("Start(): %v", err)
+	}
+
+	b.AssertActions(t, [][]string{
+		{"SetStartupArgs"},
+		{"SetArguments"},
+		{"SetArguments", "--test_sharding_strategy=disabled"},
 		{"WriteToStderr", "true"},
 		{"WriteToStdout", "true"},
 		{"Run", "--script_path=.*", "//path/to:target"},


### PR DESCRIPTION
https://github.com/bazelbuild/bazel-watcher/pull/775

Reopens the above commit

```
Fixes a bug introduced by https://github.com/bazelbuild/bazel-watcher/pull/744 where on bazel run with sharding enabled the process would fail to launch. this also requires the user to use the -- attribute before passing the flag so it gets sorted into args.

If this is not passed, the CLI will not discern between bazelArgs and args that come after --. Once this is landed, you can test a target with sharding so long as you do ibazel run //path/to/target:test -- and then whatever flags you want.
```