### PR TITLE
Use mapped repository names for watched files.

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -10,8 +10,8 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
-    "https://bcr.bazel.build/modules/apple_support/1.5.0/MODULE.bazel": "50341a62efbc483e8a2a6aec30994a58749bd7b885e18dd96aa8c33031e558ef",
-    "https://bcr.bazel.build/modules/apple_support/1.5.0/source.json": "eb98a7627c0bc486b57f598ad8da50f6625d974c8f723e9ea71bd39f709c9862",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
+    "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
@@ -19,7 +19,8 @@
     "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
-    "https://bcr.bazel.build/modules/bazel_features/1.19.0/source.json": "d7bf14517c1b25b9d9c580b0f8795fceeae08a7590f507b76aace528e941375d",
+    "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
+    "https://bcr.bazel.build/modules/bazel_features/1.27.0/source.json": "ed8cf0ef05c858dce3661689d0a2b110ff398e63994e178e4f1f7555a8067fed",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
@@ -33,16 +34,16 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/source.json": "7ebaefba0b03efe59cac88ed5bbc67bcf59a3eff33af937345ede2a38b2d368a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/source.json": "34a3c8bcf233b835eb74be9d628899bb32999d3e0eadef1947a0a562a2b16ffb",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
     "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
     "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
     "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
-    "https://bcr.bazel.build/modules/gazelle/0.44.0/MODULE.bazel": "fd3177ca0938da57a1e416cad3f39b9c4334defbc717e89aba9d9ddbbb0341da",
-    "https://bcr.bazel.build/modules/gazelle/0.44.0/source.json": "7fb65ef9c1ce470d099ca27fd478673d9d64c844af28d0d472b0874c7d590cb6",
+    "https://bcr.bazel.build/modules/gazelle/0.45.0/MODULE.bazel": "ecd19ebe9f8e024e1ccffb6d997cc893a974bcc581f1ae08f386bdd448b10687",
+    "https://bcr.bazel.build/modules/gazelle/0.45.0/source.json": "111d182facc5f5e80f0b823d5f077b74128f40c3fd2eccc89a06f34191bd3392",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
@@ -51,16 +52,17 @@
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
-    "https://bcr.bazel.build/modules/package_metadata/0.0.2/MODULE.bazel": "fb8d25550742674d63d7b250063d4580ca530499f045d70748b1b142081ebb92",
-    "https://bcr.bazel.build/modules/package_metadata/0.0.2/source.json": "e53a759a72488d2c0576f57491ef2da0cf4aab05ac0997314012495935531b73",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.5/MODULE.bazel": "ef4f9439e3270fdd6b9fd4dbc3d2f29d13888e44c529a1b243f7a31dfbc2e8e4",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.5/source.json": "2326db2f6592578177751c3e1f74786b79382cd6008834c9d01ec865b9126a85",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
-    "https://bcr.bazel.build/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
     "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
     "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
     "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
@@ -78,10 +80,12 @@
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.11/MODULE.bazel": "9f249c5624a4788067b96b8b896be10c7e8b4375dc46f6d8e1e51100113e0992",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.16/source.json": "227e83737046aa4f50015da48e98e0d8ab42fd0ec74d8d653b6cc9f9a357f200",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/source.json": "4db99b3f55c90ab28d14552aa0632533e3e8e5e9aea0f5c24ac0014282c2a7c5",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
@@ -92,9 +96,9 @@
     "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
     "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
     "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
-    "https://bcr.bazel.build/modules/rules_go/0.51.0/MODULE.bazel": "b6920f505935bfd69381651c942496d99b16e2a12f3dd5263b90ded16f3b4d0f",
-    "https://bcr.bazel.build/modules/rules_go/0.55.1/MODULE.bazel": "a57a6fc59a74326c0b440d07cca209edf13c7d1a641e48cfbeab56e79f873609",
-    "https://bcr.bazel.build/modules/rules_go/0.55.1/source.json": "827a740c8959c9d20616889e7746cde4dcc6ee80d25146943627ccea0736328f",
+    "https://bcr.bazel.build/modules/rules_go/0.53.0/MODULE.bazel": "a4ed760d3ac0dbc0d7b967631a9a3fd9100d28f7d9fcf214b4df87d4bfff5f9a",
+    "https://bcr.bazel.build/modules/rules_go/0.57.0/MODULE.bazel": "bee44028b527cd6d1b7699a2c78714bba237b40ee21f90a83b472c94bc53159d",
+    "https://bcr.bazel.build/modules/rules_go/0.57.0/source.json": "a782b756d87c68a223a48848eda4b0dac1c5fd1d925d648d7598b68aa1fb6d6d",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
@@ -148,51 +152,6 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
-    "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
-      "general": {
-        "bzlTransitiveDigest": "PjIds3feoYE8SGbbIq2SFTZy3zmxeO2tQevJZNDo7iY=",
-        "usagesDigest": "+hz7IHWN6A1oVJJWNDB6yZRG+RYhF76wAYItpAeIUIg=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "local_config_apple_cc_toolchains": {
-            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
-            "ruleClassName": "_apple_cc_autoconf_toolchains",
-            "attributes": {}
-          },
-          "local_config_apple_cc": {
-            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
-            "ruleClassName": "_apple_cc_autoconf",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "apple_support~",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
-    "@@platforms//host:extension.bzl%host_platform": {
-      "general": {
-        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
-        "usagesDigest": "hgylFkgWSg0ulUwWZzEM1aIftlUnbmw2ynWLdEfHnZc=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "host_platform": {
-            "bzlFile": "@@platforms//host:extension.bzl",
-            "ruleClassName": "host_platform_repo",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": []
-      }
-    },
     "@@rules_kotlin~//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "fus14IFJ/1LGWWGKPH/U18VnJCoMjfDt1ckahqCnM0A=",

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/bazelbuild/rules_go v0.55.1 h1:cQYGcunY8myOB+0Ym6PGQRhc/milkRcNv0my3XgxaDU=
-github.com/bazelbuild/rules_go v0.55.1/go.mod h1:T90Gpyq4HDFlsrvtQa2CBdHNJ2P4rAu/uUTmQbanzf0=
-github.com/bazelbuild/rules_go v0.56.0 h1:Ow/oLK5NRhaooY2M2f1+fBiFlGPzmvA4TSaEHisL/RQ=
-github.com/bazelbuild/rules_go v0.56.0/go.mod h1:T90Gpyq4HDFlsrvtQa2CBdHNJ2P4rAu/uUTmQbanzf0=
 github.com/bazelbuild/rules_go v0.57.0 h1:qBFxjy29iJg22xWlu5A3mNwrXtCHiEnHcIt91SsiFGU=
 github.com/bazelbuild/rules_go v0.57.0/go.mod h1:Pn30cb4M513fe2rQ6GiJ3q8QyrRsgC7zhuDvi50Lw4Y=
 github.com/fsnotify/fsevents v0.2.0 h1:BRlvlqjvNTfogHfeBOFvSC9N0Ddy+wzQCQukyoD7o/c=
@@ -26,14 +22,8 @@ github.com/smarty/assertions v1.15.0 h1:cR//PqUBUiQRakZWqBiFFQ9wb8emQGDb0HeGdqGB
 github.com/smarty/assertions v1.15.0/go.mod h1:yABtdzeQs6l1brC900WlRNwj6ZR55d7B+E8C6HtKdec=
 github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sSznIX1xY=
 github.com/smartystreets/goconvey v1.8.1/go.mod h1:+/u4qLyY6x1jReYOp7GOM2FSt8aP9CzCZL03bI28W60=
-golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
-golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
-golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
-golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=
 golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=

--- a/internal/bazel/bazel.go
+++ b/internal/bazel/bazel.go
@@ -17,6 +17,7 @@ package bazel
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -135,6 +136,7 @@ type Bazel interface {
 	WriteToStdout(v bool)
 	Query(args ...string) (*blaze_query.QueryResult, error)
 	Info() (map[string]string, *bytes.Buffer, error)
+	DumpRepoMapping(canonicalRepoName string) (map[string]string, *bytes.Buffer, error)
 	CQuery(args ...string) (*analysis.CqueryResult, error)
 	Build(args ...string) (*bytes.Buffer, error)
 	Norun(args ...string) (*bytes.Buffer, error)
@@ -276,6 +278,24 @@ func (b *bazel) processInfo(info string) (map[string]string, error) {
 	return output, nil
 }
 
+// Returns a mapping of apparent to canonical repository names under the given
+// repository. The root repository is denoted by an empty string.
+func (b *bazel) DumpRepoMapping(canonicalRepoName string) (map[string]string, *bytes.Buffer, error) {
+	b.WriteToStderr(false)
+	b.WriteToStdout(false)
+	stdoutBuffer, stderrBuffer := b.newCommand("mod", "dump_repo_mapping", canonicalRepoName)
+
+	err := b.cmd.Run()
+	if err != nil {
+		return nil, nil, err
+	}
+	var result map[string]string
+	if err := json.Unmarshal(stdoutBuffer.Bytes(), &result); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse output of dump_repo_mapping: %w", err)
+	}
+	return result, stderrBuffer, nil
+}
+
 // Executes a query language expression over a specified subgraph of the
 // build dependency graph.
 //
@@ -294,7 +314,7 @@ func (b *bazel) Query(args ...string) (*blaze_query.QueryResult, error) {
 	blazeArgs := append([]string(nil), "--output=proto", "--order_output=no", "--color=no")
 	blazeArgs = append(blazeArgs, args...)
 
-	b.WriteToStderr(true)  // revert 34c48343 (#536: Improve logging infrastructure) TODO: hide behind argument?
+	b.WriteToStderr(true) // revert 34c48343 (#536: Improve logging infrastructure) TODO: hide behind argument?
 	b.WriteToStdout(false)
 	stdoutBuffer, stderrBuff := b.newCommand("query", blazeArgs...)
 

--- a/internal/bazel/testing/mock.go
+++ b/internal/bazel/testing/mock.go
@@ -61,6 +61,10 @@ func (b *MockBazel) Info() (map[string]string, *bytes.Buffer, error) {
 	b.actions = append(b.actions, []string{"Info"})
 	return map[string]string{}, nil, nil
 }
+func (b *MockBazel) DumpRepoMapping(canonicalRepoName string) (map[string]string, *bytes.Buffer, error) {
+	b.actions = append(b.actions, []string{"DumpRepoMapping", canonicalRepoName})
+	return map[string]string{}, nil, nil
+}
 func (b *MockBazel) AddQueryResponse(query string, res *blaze_query.QueryResult) {
 	if b.queryResponse == nil {
 		b.queryResponse = map[string]*blaze_query.QueryResult{}

--- a/internal/e2e/common.go
+++ b/internal/e2e/common.go
@@ -97,10 +97,15 @@ type Args struct {
 	// all tests. If SetUp returns a non-nil error, execution is halted and
 	// tests cases are not executed.
 	SetUp func() error
+
+	// ModuleFileContent is the content of the MODULE.bazel file to be generated
+	// in the main workspace. If empty, no MODULE.bazel file will be generated
+	// and Bzlmod will be explicitly disabled.
+	ModuleFileContent string
 }
 
 func TestMain(m *testing.M, args Args) {
-	print := flag.Bool("print", false, "print out the directory listing before running the test")
+	print := flag.Bool("print", false, "print out the directory listing after SetUp but before running the test")
 
 	var skipGeneratingWorkspace bool
 	ar := txtar.Parse([]byte(args.Main))
@@ -111,6 +116,8 @@ func TestMain(m *testing.M, args Args) {
 		case ".bazelrc":
 			fmt.Printf("Do not specify a %q file in your test case. It is not allowed in order to prevent difficult to debug things, like having a .bazelrc file in the test user's home directory be accidentally detected as the one to use in here.", f.Name)
 			os.Exit(1)
+		case "MODULE.bazel":
+			args.ModuleFileContent = string(f.Data)
 		}
 	}
 
@@ -122,9 +129,33 @@ func TestMain(m *testing.M, args Args) {
 `
 	}
 
+	// We must set _some_ non-emoty suffix, so that the generated `.bazelrc`
+	// enables the use of Bzlmod. Otherwise `TestMain` would automatically
+	// disable the feature. The auto-generated `MODULE.bazel` is not suitable
+	// for us since it tries to target `rules_go`.
+	var moduleFileSuffix string
+	if args.ModuleFileContent != "" {
+		moduleFileSuffix = "placeholder"
+	}
+
 	bazel_testing.TestMain(m, bazel_testing.Args{
-		Main: args.Main + additional,
+		Main:             args.Main + additional,
+		ModuleFileSuffix: moduleFileSuffix,
 		SetUp: func() error {
+			if args.ModuleFileContent != "" {
+				// Fully replace the auto-generated MODULE.bazel with the
+				// provided content.
+				if err := ioutil.WriteFile("MODULE.bazel", []byte(args.ModuleFileContent), 0777); err != nil {
+					return fmt.Errorf("Failed to write main MODULE.bazel: %w", err)
+				}
+			}
+
+			if args.SetUp != nil {
+				if err := args.SetUp(); err != nil {
+					return err
+				}
+			}
+
 			if *print {
 				if err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 					if d.IsDir() {
@@ -135,12 +166,6 @@ func TestMain(m *testing.M, args Args) {
 					return nil
 				}); err != nil {
 					return fmt.Errorf("WalkDir(.): %w", err)
-				}
-			}
-
-			if args.SetUp != nil {
-				if err := args.SetUp(); err != nil {
-					return err
 				}
 			}
 

--- a/internal/e2e/ibazel.go
+++ b/internal/e2e/ibazel.go
@@ -134,8 +134,7 @@ func (i *IBazelTester) runWithFixCommands(target string, prebuild bool) {
 		"--graceful_termination_wait_duration=1s",
 		"--run_output=true",
 		"--run_output_interactive=false",
-	},
-	prebuild)
+	}, prebuild)
 }
 
 func (i *IBazelTester) RunWithBazelFixCommands(target string) {

--- a/internal/e2e/nested_modules/BUILD
+++ b/internal/e2e/nested_modules/BUILD
@@ -1,0 +1,7 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "nested_module_test",
+    srcs = ["nested_module_test.go"],
+    deps = ["//internal/e2e"],
+)

--- a/internal/e2e/nested_modules/nested_module_test.go
+++ b/internal/e2e/nested_modules/nested_module_test.go
@@ -1,0 +1,111 @@
+package simple
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/bazelbuild/bazel-watcher/internal/e2e"
+)
+
+const nestedBuild = `
+sh_library(
+	name = "lib",
+	data = ["lib.sh"],
+	visibility = ["//visibility:public"],
+)
+`
+
+const nestedLib = `
+function say_hello {
+	printf "hello!"
+}
+`
+
+const nestedLibAlt = `
+function say_hello {
+	printf "hello2!"
+}
+`
+
+const mainFiles = `
+-- .bazelversion --
+6.5.0
+-- BUILD.bazel --
+sh_binary(
+    name = "test",
+    srcs = ["test.sh"],
+    args = ["$(location @nested//:lib)"],
+    deps = ["@nested//:lib"],
+)
+-- test.sh --
+#!/bin/bash
+source "$1"
+say_hello
+`
+
+const mainModuleFile = `
+module(name = "primary")
+bazel_dep(name = "nested_module", repo_name = "nested")
+local_path_override(
+    module_name = "nested_module",
+    path = "./nested/",
+)
+`
+
+const nestedModuleFile = `
+module(
+	name = "nested_module",
+	repo_name = "nested",
+)
+`
+
+var nestedWd string
+
+func TestMain(m *testing.M) {
+	e2e.TestMain(m, e2e.Args{
+		Main:              mainFiles,
+		ModuleFileContent: mainModuleFile,
+		SetUp: func() error {
+			// Create a nested module in a subfolder.
+			nestedWd, _ = filepath.Abs("nested")
+
+			// Manually create files in the nested module.
+			if err := os.Mkdir(nestedWd, 0777); err != nil {
+				log.Fatalf("os.Mkdir(%q): %v", nestedWd, err)
+			}
+			for file, contents := range map[string]string{
+				".bazelversion": "6.5.0", // Needed for built-in sh_binary.
+				"BUILD.bazel":   nestedBuild,
+				"lib.sh":        nestedLib,
+				"WORKSPACE":     "# No content since we are using MODULE.bazel.",
+				"MODULE.bazel":  nestedModuleFile,
+			} {
+				if err := ioutil.WriteFile(filepath.Join(nestedWd, file), []byte(contents), 0777); err != nil {
+					log.Fatalf("Failed to write file %q: %v", file, err)
+				}
+			}
+
+			return nil
+		},
+	})
+}
+
+func TestRunWithModifiedFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skipf("--override_repository is not implemented in windows")
+	}
+
+	ibazel := e2e.SetUp(t)
+	ibazel.Run([]string{}, "//:test")
+	defer ibazel.Kill()
+
+	ibazel.ExpectOutput("hello!")
+
+	ioutil.WriteFile(
+		filepath.Join(nestedWd, "lib.sh"), []byte(nestedLibAlt), 0777)
+	ibazel.ExpectOutput("hello2!")
+}

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -480,6 +480,18 @@ func (i *IBazel) getInfo() (map[string]string, *bytes.Buffer, error) {
 	return res, stderrBuffer, nil
 }
 
+func (i *IBazel) dumpRootRepoMapping() (map[string]string, *bytes.Buffer, error) {
+	b := i.newBazel()
+
+	res, stderr, err := b.DumpRepoMapping("")
+	if err != nil {
+		log.Errorf("Error dumping Bazel repo mapping: %v", err)
+		return nil, nil, err
+	}
+
+	return res, stderr, nil
+}
+
 func (i *IBazel) queryForSourceFiles(query string) ([]string, error) {
 	b := i.newBazel()
 

--- a/internal/ibazel/ibazel_unix.go
+++ b/internal/ibazel/ibazel_unix.go
@@ -18,7 +18,6 @@
 package ibazel
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -36,9 +35,6 @@ func (i *IBazel) realLocalRepositoryPaths() (map[string]string, error) {
 
 	outputBase := info["output_base"]
 	installBase := info["install_base"]
-	if false {
-		return nil, fmt.Errorf("`bazel info` didn't include install_base")
-	}
 	externalPath := filepath.Join(outputBase, "external")
 
 	files, err := ioutil.ReadDir(externalPath)
@@ -61,6 +57,23 @@ func (i *IBazel) realLocalRepositoryPaths() (map[string]string, error) {
 
 			localRepositories[name] = realPath
 		}
+	}
+
+	// Replace the canonical repository name with the actual repository name
+	// from the repository mapping known to Bazel.
+	if len(localRepositories) > 0 {
+		if repoMapping, _, err := i.dumpRootRepoMapping(); err == nil { // if NO error
+			for repo, canonical := range repoMapping {
+				if realPath, ok := localRepositories[canonical]; ok {
+					delete(localRepositories, canonical)
+					localRepositories[repo] = realPath
+				}
+			}
+		} else {
+			// Don't fail on this. We will try without the mapping.
+			log.Errorf("Error finding repository mapping: %v\n", err)
+		}
+
 	}
 
 	// Apply overrides set via arguments. Overrides must already be absolute.


### PR DESCRIPTION
Bazel repositories have a canonical and a mapped/apparent name. The apparent name appears in labels whereas the canonical name is used in the file tree. The old logic was not taking mappings into account. This would lead to files being discard from watching due to their labels having the apparent name.

Example:

```starlark
bazel_dep(name = "my_cool_dep", repo = "foo")
```

This would lead to files inside the repository having labels starting with `@foo//...`. The canonical repo name is `my_cool_dep+` so the path on disk is something like `.../external/my_cool_dep+`. The old logic would look at the `bazel query` results and check for `my_cool_dep+` as the repository name, but it was actually `foo` which maps to `my_cool_dep+`. All files were discarded from watching and `ibazel` printed *Didn't find any files to watch from query*.