### PR TITLE
use cquery for resolving files and dependencies

### DIFF
--- a/internal/bazel/testing/mock.go
+++ b/internal/bazel/testing/mock.go
@@ -16,7 +16,10 @@ package testing
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
 	"regexp"
 	"testing"
@@ -32,6 +35,7 @@ type MockBazel struct {
 	cqueryResponse map[string]*analysis.CqueryResult
 	args           []string
 	startupArgs    []string
+	info           map[string]string
 
 	buildError error
 	waitError  error
@@ -51,6 +55,9 @@ func (b *MockBazel) SetStartupArgs(args []string) {
 	b.startupArgs = args
 }
 
+func (b *MockBazel) SetInfo(info map[string]string) {
+	b.info = info
+}
 func (b *MockBazel) WriteToStderr(v bool) {
 	b.actions = append(b.actions, []string{"WriteToStderr", fmt.Sprint(v)})
 }
@@ -59,7 +66,7 @@ func (b *MockBazel) WriteToStdout(v bool) {
 }
 func (b *MockBazel) Info() (map[string]string, *bytes.Buffer, error) {
 	b.actions = append(b.actions, []string{"Info"})
-	return map[string]string{}, nil, nil
+	return b.info, nil, nil
 }
 func (b *MockBazel) DumpRepoMapping(canonicalRepoName string) (map[string]string, *bytes.Buffer, error) {
 	b.actions = append(b.actions, []string{"DumpRepoMapping", canonicalRepoName})
@@ -73,9 +80,12 @@ func (b *MockBazel) AddQueryResponse(query string, res *blaze_query.QueryResult)
 }
 func (b *MockBazel) Query(args ...string) (*blaze_query.QueryResult, error) {
 	b.actions = append(b.actions, append([]string{"Query"}, args...))
-	query := args[0]
+	queryArgs, err := parseQueryArgs(args)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse query args: %v", err))
+	}
+	query := queryArgs[0]
 	res, ok := b.queryResponse[query]
-
 	if !ok {
 		var candidates []string
 		for candidate := range b.queryResponse {
@@ -161,9 +171,19 @@ func (b *MockBazel) AssertActions(t *testing.T, expected [][]string) {
 	}
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
+func parseQueryArgs(args []string) ([]string, error) {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	queryFile := fs.String("query_file", "", "")
+	if err := fs.Parse(args); err != nil {
+		return args, nil
 	}
-	return b
+	if *queryFile == "" {
+		return args, nil
+	}
+	contents, err := os.ReadFile(*queryFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read query file: %w", err)
+	}
+	return []string{string(contents)}, nil
 }

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -61,7 +61,8 @@ const (
 )
 
 const sourceQuery = "kind('source file', deps(set(%s)))"
-const buildQuery = "buildfiles(deps(set(%s)))"
+const targetQuery = "deps(set(%s))"
+const buildQuery = "buildfiles(set(%s))"
 
 type IBazel struct {
 	debounceDuration time.Duration
@@ -311,8 +312,21 @@ func (i *IBazel) iteration(command string, commandToRun runnableCommand, targets
 	case QUERY:
 		// Query for which files to watch.
 		log.Logf("Querying for files to watch...")
-		i.watchFiles(fmt.Sprintf(buildQuery, joinedTargets), i.buildFileWatcher)
-		i.watchFiles(fmt.Sprintf(sourceQuery, joinedTargets), i.sourceFileWatcher)
+
+		toWatchBuildFiles, err := i.queryForBuildFiles(joinedTargets)
+		if err != nil {
+			log.Errorf("Error querying for build files: %v", err)
+		} else {
+			i.watchFiles(toWatchBuildFiles, i.buildFileWatcher)
+		}
+
+		toWatchSourceFiles, err := i.queryForSourceFiles(joinedTargets)
+		if err != nil {
+			log.Errorf("Error querying for source files: %v", err)
+		} else {
+			i.watchFiles(toWatchSourceFiles, i.sourceFileWatcher)
+		}
+
 		i.state = RUN
 	case DEBOUNCE_RUN:
 		select {
@@ -492,63 +506,96 @@ func (i *IBazel) dumpRootRepoMapping() (map[string]string, *bytes.Buffer, error)
 	return res, stderr, nil
 }
 
-func (i *IBazel) queryForSourceFiles(query string) ([]string, error) {
+func (i *IBazel) queryForSourceFiles(targets string) ([]string, error) {
 	b := i.newBazel()
 
-	localRepositories, err := i.realLocalRepositoryPaths()
+	res, err := b.CQuery(i.cQueryArgs(fmt.Sprintf(sourceQuery, targets))...)
 	if err != nil {
+		log.Errorf("Bazel cquery failed: %v", err)
 		return nil, err
 	}
 
-	res, err := b.Query(i.queryArgs(query)...)
-	if err != nil {
-		log.Errorf("Bazel query failed: %v", err)
-		return nil, err
-	}
-
-	workspacePath, err := i.workspaceFinder.FindWorkspace()
-	if err != nil {
-		log.Errorf("Error finding workspace: %v", err)
-		return nil, err
-	}
-
-	toWatch := make([]string, 0, len(res.GetTarget()))
-	for _, target := range res.GetTarget() {
-		switch *target.Type {
+	labels := make([]string, 0, len(res.Results))
+	for _, target := range res.Results {
+		switch *target.Target.Type {
 		case blaze_query.Target_SOURCE_FILE:
-			label := target.GetSourceFile().GetName()
-			if strings.HasPrefix(label, "@") {
-				repo, target := parseTarget(label)
-				if realPath, ok := localRepositories[repo]; ok {
-					label = strings.Replace(target, ":", string(filepath.Separator), 1)
-					toWatch = append(toWatch, filepath.Join(realPath, label))
-					break
-				}
-				continue
-			}
-			if strings.HasPrefix(label, "//external") {
-				continue
-			}
-
-			label = strings.Replace(strings.TrimPrefix(label, "//"), ":", string(filepath.Separator), 1)
-			toWatch = append(toWatch, filepath.Join(workspacePath, label))
-			break
+			label := target.Target.SourceFile.GetName()
+			labels = append(labels, label)
 		default:
 			log.Errorf("%v\n", target)
 		}
 	}
 
-	return toWatch, nil
+	return i.labelsToWatch(labels)
 }
 
-func (i *IBazel) watchFiles(query string, watcher common.Watcher) {
-	toWatch, err := i.queryForSourceFiles(query)
+func (i *IBazel) queryForBuildFiles(targets string) ([]string, error) {
+	b := i.newBazel()
+
+	targetRes, err := b.CQuery(i.cQueryArgs(fmt.Sprintf(targetQuery, targets))...)
 	if err != nil {
-		// If the query fails, just keep watching the same files as before
-		log.Errorf("Error querying for source files: %v", err)
-		return
+		log.Errorf("Bazel target query failed: %v", err)
+		return nil, err
 	}
 
+	localRepositories, err := i.realLocalRepositoryPaths()
+	if err != nil {
+		return nil, err
+	}
+	quotedBuildTargets := make([]string, 0, len(targetRes.Results))
+	for _, configuredTarget := range targetRes.Results {
+		target := configuredTarget.GetTarget()
+		if *target.Type == blaze_query.Target_RULE {
+			label := target.GetRule().GetName()
+			if strings.HasPrefix(label, "@") {
+				repo, _ := parseTarget(label)
+				if _, ok := localRepositories[repo]; !ok {
+					continue
+				}
+			}
+			if strings.HasPrefix(label, "//external") {
+				continue
+			}
+			// Build targets may contain characters that shells don't like.
+			// Quote them to guarantee the correct behavior.
+			quotedBuildTargets = append(quotedBuildTargets, fmt.Sprintf("%q", label))
+		}
+	}
+
+	f, err := os.CreateTemp("", "query")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create query file: %w", err)
+	}
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+	_, err = f.WriteString(fmt.Sprintf(buildQuery, strings.Join(quotedBuildTargets, " ")))
+	if err != nil {
+		return nil, fmt.Errorf("failed to write query file: %w", err)
+	}
+
+	res, err := b.Query(i.queryArgs(fmt.Sprintf("--query_file=%s", f.Name()))...)
+	if err != nil {
+		log.Errorf("Bazel query failed: %v", err)
+		return nil, err
+	}
+
+	labels := make([]string, 0, len(res.GetTarget()))
+	for _, target := range res.GetTarget() {
+		switch *target.Type {
+		case blaze_query.Target_SOURCE_FILE:
+			label := target.GetSourceFile().GetName()
+			labels = append(labels, label)
+		default:
+			log.Errorf("%v\n", target)
+		}
+	}
+
+	return i.labelsToWatch(labels)
+}
+
+func (i *IBazel) watchFiles(toWatch []string, watcher common.Watcher) {
 	filesWatched := map[string]struct{}{}
 	uniqueDirectories := map[string]struct{}{}
 
@@ -569,16 +616,50 @@ func (i *IBazel) watchFiles(query string, watcher common.Watcher) {
 	}
 
 	watchList := keys(uniqueDirectories)
-	err = watcher.UpdateAll(watchList)
+	err := watcher.UpdateAll(watchList)
 	if err != nil {
 		log.Errorf("Error(s) updating watch list:\n %v", err)
 	}
 
 	if len(filesWatched) == 0 {
-		log.Errorf("Didn't find any files to watch from query %s", query)
+		log.Errorf("Didn't find any files to watch for")
 	}
 
 	i.filesWatched[watcher] = filesWatched
+}
+
+func (i *IBazel) labelsToWatch(labels []string) ([]string, error) {
+	localRepositories, err := i.realLocalRepositoryPaths()
+	if err != nil {
+		return nil, err
+	}
+
+	workspacePath, err := i.workspaceFinder.FindWorkspace()
+	if err != nil {
+		log.Errorf("Error finding workspace: %v", err)
+		return nil, err
+	}
+
+	toWatch := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if strings.HasPrefix(label, "@") {
+			repo, target := parseTarget(label)
+			if realPath, ok := localRepositories[repo]; ok {
+				label = strings.Replace(target, ":", string(filepath.Separator), 1)
+				toWatch = append(toWatch, filepath.Join(realPath, label))
+				break
+			}
+			continue
+		}
+		if strings.HasPrefix(label, "//external") {
+			continue
+		}
+
+		label = strings.Replace(strings.TrimPrefix(label, "//"), ":", string(filepath.Separator), 1)
+		toWatch = append(toWatch, filepath.Join(workspacePath, label))
+	}
+
+	return toWatch, nil
 }
 
 func (i *IBazel) queryArgs(args ...string) []string {

--- a/internal/ibazel/ibazel_test.go
+++ b/internal/ibazel/ibazel_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"runtime/debug"
@@ -188,8 +189,68 @@ func TestIBazelLoop(t *testing.T) {
 	log.SetTesting(t)
 
 	i, mockBazel := newIBazel(t)
-	mockBazel.AddQueryResponse("buildfiles(deps(set(//my:target)))", &blaze_query.QueryResult{})
-	mockBazel.AddQueryResponse("kind('source file', deps(set(//my:target)))", &blaze_query.QueryResult{})
+
+	ruleType := blaze_query.Target_RULE
+	sourceFileType := blaze_query.Target_SOURCE_FILE
+	target := "//my:target"
+	sourceDir := t.TempDir()
+
+	basePath := filepath.Join(sourceDir, "path", "to")
+	if err := os.MkdirAll(basePath, 0o700); err != nil {
+		t.Errorf("failed to create based path: %v", err)
+		t.FailNow()
+	}
+
+	buildFilePath := filepath.Join(basePath, "BUILD")
+	sourceFilePath := filepath.Join(basePath, "foo")
+
+	if err := os.WriteFile(buildFilePath, []byte(""), 0o700); err != nil {
+		t.Errorf("failed to create BUILD file: %v", err)
+		t.FailNow()
+	}
+	if err := os.WriteFile(sourceFilePath, []byte(""), 0o700); err != nil {
+		t.Errorf("failed to create source file: %v", err)
+		t.FailNow()
+	}
+
+	mockBazel.AddQueryResponse(fmt.Sprintf("buildfiles(set(%q))", target), &blaze_query.QueryResult{
+		Target: []*blaze_query.Target{{
+			Type: &sourceFileType,
+			SourceFile: &blaze_query.SourceFile{
+				Name: &buildFilePath,
+			},
+		}},
+	})
+	mockBazel.AddCQueryResponse(fmt.Sprintf("deps(set(%s))", target), &analysispb.CqueryResult{
+		Results: []*analysispb.ConfiguredTarget{{
+			Target: &blaze_query.Target{
+				Type: &ruleType,
+				Rule: &blaze_query.Rule{
+					Name: &target,
+				},
+			},
+		}},
+	})
+	mockBazel.AddCQueryResponse(fmt.Sprintf("kind('source file', deps(set(%s)))", target), &analysispb.CqueryResult{
+		Results: []*analysispb.ConfiguredTarget{{
+			Target: &blaze_query.Target{
+				Type: &sourceFileType,
+				SourceFile: &blaze_query.SourceFile{
+					Name: &sourceFilePath,
+				},
+			},
+		}},
+	})
+
+	outputBase := t.TempDir()
+	if err := os.Mkdir(filepath.Join(outputBase, "external"), 0o700); err != nil {
+		t.Errorf("failed to create external directory: %v", err)
+		t.FailNow()
+	}
+	mockBazel.SetInfo(map[string]string{
+		"output_base":  outputBase,
+		"install_base": t.TempDir(),
+	})
 
 	// Replace the file watching channels with ones that have buffers.
 	fakeBuildWatcher := &fakeFSNotifyWatcher{
@@ -223,7 +284,7 @@ func TestIBazelLoop(t *testing.T) {
 
 	i.state = QUERY
 	step := func() {
-		i.iteration("demo", command, []string{}, "//my:target")
+		i.iteration("demo", command, []string{}, target)
 	}
 	assertRun := func() {
 		t.Helper()
@@ -248,14 +309,14 @@ func TestIBazelLoop(t *testing.T) {
 
 	assertState(QUERY)
 	step()
-	i.filesWatched[fakeBuildWatcher]["/path/to/BUILD"] = struct{}{}
-	i.filesWatched[fakeSourceWatcher]["/path/to/foo"] = struct{}{}
+	i.filesWatched[fakeBuildWatcher][buildFilePath] = struct{}{}
+	i.filesWatched[fakeSourceWatcher][sourceFilePath] = struct{}{}
 	assertState(RUN)
 	step() // Actually run the command
 	assertRun()
 	assertState(WAIT)
 	// Source file change.
-	go func() { i.sourceFileWatcher.Events() <- common.Event{Op: common.Write, Name: "/path/to/foo"} }()
+	go func() { i.sourceFileWatcher.Events() <- common.Event{Op: common.Write, Name: sourceFilePath} }()
 	step()
 	assertState(DEBOUNCE_RUN)
 	step()
@@ -265,7 +326,7 @@ func TestIBazelLoop(t *testing.T) {
 	assertRun()
 	assertState(WAIT)
 	// Build file change.
-	i.buildFileWatcher.Events() <- common.Event{Op: common.Write, Name: "/path/to/BUILD"}
+	i.buildFileWatcher.Events() <- common.Event{Op: common.Write, Name: buildFilePath}
 	step()
 	assertState(DEBOUNCE_QUERY)
 	// Don't send another event in to test the timer
@@ -284,7 +345,7 @@ func TestIBazelBuild(t *testing.T) {
 	i, mockBazel := newIBazel(t)
 	defer i.Cleanup()
 
-	mockBazel.AddQueryResponse("//path/to:target", &blaze_query.QueryResult{
+	mockBazel.AddQueryResponse("\"//path/to:target\"", &blaze_query.QueryResult{
 		Target: []*blaze_query.Target{
 			{
 				Type: blaze_query.Target_RULE.Enum(),


### PR DESCRIPTION
Use `cquery` for most query applications except for `BUILD` files. This makes queries more accurate to real builds since `select` statements and flags are evaluated. This should also prevent unnecessary cache invalidation from regular queries without flags.

Revival of #672. I've changed the original PR by fixing tests and quoting targets in the query file for better robustness. I manually tested this on our big repo which currently errors with `ibazel` due to `bazel query` traversing into places that would not ordinarily be on the action graph in builds.