### PR TITLE
Show when `bazel run` exited with code

### DIFF
--- a/internal/bazel/bazel.go
+++ b/internal/bazel/bazel.go
@@ -142,7 +142,6 @@ type Bazel interface {
 	Norun(args ...string) (*bytes.Buffer, error)
 	Test(args ...string) (*bytes.Buffer, error)
 	Run(args ...string) (*exec.Cmd, *bytes.Buffer, error)
-	Wait() error
 	Cancel()
 }
 
@@ -415,16 +414,6 @@ func (b *bazel) Run(args ...string) (*exec.Cmd, *bytes.Buffer, error) {
 	}
 
 	return b.cmd, stderrBuffer, err
-}
-
-func (b *bazel) Wait() error {
-	res := b.cmd.Wait()
-	if res.Error() == "exec: Wait was already called" {
-		if b.cmd.ProcessState.Success() {
-			return nil
-		}
-	}
-	return res
 }
 
 // Cancel the currently running operation. Useful if you call Run(target) and

--- a/internal/e2e/exit_code/BUILD
+++ b/internal/e2e/exit_code/BUILD
@@ -1,0 +1,7 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "exit_code_test",
+    srcs = ["exit_code_test.go"],
+    deps = ["//internal/e2e"],
+)

--- a/internal/e2e/exit_code/exit_code_test.go
+++ b/internal/e2e/exit_code/exit_code_test.go
@@ -1,0 +1,44 @@
+package lifecycle_hooks
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/bazel-watcher/internal/e2e"
+)
+
+const mainFiles = `
+-- BUILD.bazel --
+sh_binary(
+  name = "test",
+  srcs = ["test.sh"],
+)
+sh_binary(
+  name = "failure",
+  srcs = ["failure.sh"],
+)
+-- test.sh --
+-- failure.sh --
+exit 42
+`
+
+func TestMain(m *testing.M) {
+	e2e.TestMain(m, e2e.Args{
+		Main: mainFiles,
+	})
+}
+
+func TestExitCode(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	defer ibazel.Kill()
+
+	ibazel.Run([]string{}, "//:test")
+	ibazel.ExpectIBazelError("Exited \\(0\\)")
+}
+
+func TestExitCodeFailure(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	defer ibazel.Kill()
+
+	ibazel.Run([]string{}, "//:failure")
+	ibazel.ExpectIBazelError("Exited \\(42\\)")
+}

--- a/internal/ibazel/command/command.go
+++ b/internal/ibazel/command/command.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 	"syscall"
@@ -82,42 +81,22 @@ func start(b bazel.Bazel, target string, args []string) (*bytes.Buffer, process_
 	return outputBuffer, cmd
 }
 
-func subprocessRunning(cmd *exec.Cmd) bool {
-	if cmd == nil {
-		return false
-	}
-	if cmd.Process == nil {
-		return false
-	}
-	if cmd.ProcessState != nil {
-		if cmd.ProcessState.Exited() {
-			return false
-		}
-	}
-
-	return true
-}
-
-func terminate(pg process_group.ProcessGroup) {
+func terminate(pg process_group.ProcessGroup, doneChan chan bool) {
 	pg.Signal(syscall.SIGTERM)
-	done := make(chan bool, 1)
 	go func() {
 		select {
 		case <-time.After(*waitDuration):
 			log.Logf("The subprocess wasn't terminated within %s. Forcing to close.", *waitDuration)
 			kill(pg)
-		case <-done:
+			<-doneChan
+		case <-doneChan:
 			// The subprocess was terminated with SIGTERM
 		}
 	}()
-	pg.Wait()
-	done <- true
 	pg.Close()
 }
 
 func kill(pg process_group.ProcessGroup) {
-	if subprocessRunning(pg.RootProcess()) {
-		log.Logf("Sending SIGKILL to the subprocess")
-		pg.Signal(syscall.SIGKILL)
-	}
+	log.Log("Sending SIGKILL to the subprocess")
+	pg.Signal(syscall.SIGKILL)
 }

--- a/internal/ibazel/command/command_test.go
+++ b/internal/ibazel/command/command_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/bazel-watcher/internal/bazel"
-	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
-	"github.com/bazelbuild/bazel-watcher/internal/ibazel/process_group"
 )
 
 var oldExecCommand = execCommand
@@ -35,39 +33,5 @@ func assertKilled(t *testing.T, cmd *exec.Cmd) {
 		if cmd.ProcessState == nil {
 			t.Errorf("Killable subprocess was never started. State: %v, Err: %v", cmd.ProcessState, err)
 		}
-	}
-}
-
-func TestSubprocessRunning(t *testing.T) {
-	log.SetLogger(t)
-
-	execCommand = func(name string, args ...string) process_group.ProcessGroup {
-		return oldExecCommand("ls") // Every system has ls.
-	}
-	defer func() { execCommand = oldExecCommand }()
-
-	if subprocessRunning(nil) {
-		t.Errorf("Nil subprocesses don't run")
-	}
-
-	cmd := exec.Command("sleep", ".1")
-
-	if subprocessRunning(cmd) {
-		t.Errorf("New subprocess shouldn't have been started yet. State: %v", cmd.ProcessState)
-	}
-
-	if err := cmd.Start(); err != nil {
-		t.Errorf("cmd.Start(): %v", err)
-	}
-
-	if !subprocessRunning(cmd) {
-		t.Errorf("New subprocess was never started. State: %v", cmd.ProcessState)
-	}
-
-	err := cmd.Wait()
-	if err != nil {
-		t.Errorf("Subprocess finished with error: %v State: %v", err, cmd.ProcessState)
-	} else if subprocessRunning(cmd) {
-		t.Errorf("Subprocess still running State: %v", cmd.ProcessState)
 	}
 }

--- a/internal/ibazel/command/default_command.go
+++ b/internal/ibazel/command/default_command.go
@@ -17,19 +17,23 @@ package command
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"sync"
+	"sync/atomic"
 
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/process_group"
 )
 
 type defaultCommand struct {
-	target      string
-	startupArgs []string
-	bazelArgs   []string
-	args        []string
-	pg          process_group.ProcessGroup
-	termSync    sync.Once
+	target            string
+	startupArgs       []string
+	bazelArgs         []string
+	args              []string
+	pg                process_group.ProcessGroup
+	termSync          sync.Once
+	doneChan          chan bool
+	subprocessRunning atomic.Bool
 }
 
 // DefaultCommand is the normal mode of interacting with iBazel. If you start a
@@ -50,13 +54,14 @@ func (c *defaultCommand) Terminate() {
 		return
 	}
 	c.termSync.Do(func() {
-		terminate(c.pg)
+		terminate(c.pg, c.doneChan)
 	})
 	c.pg = nil
+	c.subprocessRunning.Store(false)
 }
 
 func (c *defaultCommand) Kill() {
-	if c.pg != nil {
+	if !c.IsSubprocessRunning() {
 		kill(c.pg)
 	}
 }
@@ -70,16 +75,35 @@ func (c *defaultCommand) Start() (*bytes.Buffer, error) {
 	b.WriteToStdout(true)
 
 	var outputBuffer *bytes.Buffer
-	outputBuffer, c.pg = start(b, c.target, c.args)
+	outputBuffer, pg := start(b, c.target, c.args)
+	c.pg = pg
+	doneChan := make(chan bool, 1)
+	c.doneChan = doneChan
+	c.subprocessRunning.Store(true)
 
-	c.pg.RootProcess().Env = os.Environ()
+	pg.RootProcess().Env = os.Environ()
 
 	var err error
-	if err = c.pg.Start(); err != nil {
+	if err = pg.Start(); err != nil {
 		log.Errorf("Error starting process: %v", err)
 		return outputBuffer, err
 	}
 	log.Log("Starting...")
+
+	logf := log.Logf
+	go func() {
+		err := pg.Wait()
+
+		code := 0
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			code = exiterr.ExitCode()
+		}
+		logf("Exited (%d)", code)
+
+		doneChan <- true
+		c.subprocessRunning.Store(false)
+	}()
+
 	c.termSync = sync.Once{}
 	return outputBuffer, nil
 }
@@ -91,5 +115,5 @@ func (c *defaultCommand) NotifyOfChanges() *bytes.Buffer {
 }
 
 func (c *defaultCommand) IsSubprocessRunning() bool {
-	return c.pg != nil && subprocessRunning(c.pg.RootProcess())
+	return c.subprocessRunning.Load()
 }

--- a/internal/ibazel/command/default_command_test.go
+++ b/internal/ibazel/command/default_command_test.go
@@ -57,6 +57,7 @@ func TestDefaultCommand(t *testing.T) {
 	}
 
 	toKill.Start()
+	c.subprocessRunning.Store(true)
 
 	if !c.IsSubprocessRunning() {
 		t.Errorf("New subprocess was never started. State: %v", toKill.RootProcess().ProcessState)

--- a/internal/ibazel/command/notify_command.go
+++ b/internal/ibazel/command/notify_command.go
@@ -18,20 +18,24 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"os/exec"
 	"sync"
+	"sync/atomic"
 
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/process_group"
 )
 
 type notifyCommand struct {
-	target      string
-	startupArgs []string
-	bazelArgs   []string
-	args        []string
-	pg          process_group.ProcessGroup
-	stdin       io.WriteCloser
-	termSync    sync.Once
+	target            string
+	startupArgs       []string
+	bazelArgs         []string
+	args              []string
+	pg                process_group.ProcessGroup
+	stdin             io.WriteCloser
+	termSync          sync.Once
+	doneChan          chan bool
+	subprocessRunning atomic.Bool
 }
 
 // NotifyCommand is an alternate mode for starting a command. In this mode the
@@ -51,13 +55,14 @@ func (c *notifyCommand) Terminate() {
 		return
 	}
 	c.termSync.Do(func() {
-		terminate(c.pg)
+		terminate(c.pg, c.doneChan)
 	})
 	c.pg = nil
+	c.subprocessRunning.Store(false)
 }
 
 func (c *notifyCommand) Kill() {
-	if c.pg != nil {
+	if !c.IsSubprocessRunning() {
 		kill(c.pg)
 	}
 }
@@ -71,22 +76,42 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 	b.WriteToStdout(true)
 
 	var outputBuffer *bytes.Buffer
-	outputBuffer, c.pg = start(b, c.target, c.args)
+	outputBuffer, pg := start(b, c.target, c.args)
+	c.pg = pg
+	doneChan := make(chan bool, 1)
+	c.doneChan = doneChan
+	c.subprocessRunning.Store(true)
+
 	// Keep the writer around.
 	var err error
-	c.stdin, err = c.pg.RootProcess().StdinPipe()
+	c.stdin, err = pg.RootProcess().StdinPipe()
 	if err != nil {
 		log.Errorf("Error getting stdin pipe: %v", err)
 		return outputBuffer, err
 	}
 
-	c.pg.RootProcess().Env = append(os.Environ(), "IBAZEL_NOTIFY_CHANGES=y")
+	pg.RootProcess().Env = append(os.Environ(), "IBAZEL_NOTIFY_CHANGES=y")
 
-	if err = c.pg.Start(); err != nil {
+	if err = pg.Start(); err != nil {
 		log.Errorf("Error starting process: %v", err)
 		return outputBuffer, err
 	}
 	log.Log("Starting...")
+
+	logf := log.Logf
+	go func() {
+		err := pg.Wait()
+
+		code := 0
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			code = exiterr.ExitCode()
+		}
+		logf("Exited (%d)", code)
+
+		doneChan <- true
+		c.subprocessRunning.Store(false)
+	}()
+
 	c.termSync = sync.Once{}
 	return outputBuffer, nil
 }
@@ -127,5 +152,5 @@ func (c *notifyCommand) NotifyOfChanges() *bytes.Buffer {
 }
 
 func (c *notifyCommand) IsSubprocessRunning() bool {
-	return c.pg != nil && subprocessRunning(c.pg.RootProcess())
+	return c.subprocessRunning.Load()
 }

--- a/internal/ibazel/command/notify_command_test.go
+++ b/internal/ibazel/command/notify_command_test.go
@@ -53,8 +53,10 @@ func TestNotifyCommand(t *testing.T) {
 	defer func() { bazelNew = oldBazelNew }()
 
 	c.NotifyOfChanges()
+	c.subprocessRunning.Store(true)
 	b.BuildError(errors.New("Demo error"))
 	c.NotifyOfChanges()
+	c.subprocessRunning.Store(false)
 	b.BuildError(nil)
 	c.NotifyOfChanges()
 
@@ -99,11 +101,16 @@ func TestNotifyCommand_Restart(t *testing.T) {
 	defer func() { execCommand = oldExecCommand }()
 
 	c := &notifyCommand{
-		args:      []string{"moo"},
-		bazelArgs: []string{},
-		pg:        pg,
-		target:    "//path/to:target",
+		args:              []string{"moo"},
+		bazelArgs:         []string{},
+		pg:                pg,
+		target:            "//path/to:target",
 	}
+
+	go func() {
+		pg.Wait()
+		c.subprocessRunning.Store(false)
+	}()
 
 	var err error
 	c.stdin, err = pg.RootProcess().StdinPipe()

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -187,6 +187,9 @@ func (i *IBazel) SetDebounceDuration(debounceDuration time.Duration) {
 }
 
 func (i *IBazel) Cleanup() {
+	if i.cmd != nil {
+		i.cmd.Terminate()
+	}
 	i.buildFileWatcher.Close()
 	i.sourceFileWatcher.Close()
 	for _, l := range i.lifecycleListeners {

--- a/internal/ibazel/ibazel_test.go
+++ b/internal/ibazel/ibazel_test.go
@@ -105,7 +105,7 @@ func (m *mockCommand) NotifyOfChanges() *bytes.Buffer {
 }
 func (m *mockCommand) Terminate() {
 	if !m.started {
-		panic("Terminated before starting")
+		return
 	}
 	m.signalChan <- syscall.SIGTERM
 	<-m.doTermChan


### PR DESCRIPTION
Hi,

As I'm using ibazel to develop and run a short-lived binary, I though it'd be good to have ibazel show when the binary has exited. A message "Starting..." is displayed at the beginning, this PR adds a message "Exited (code)" at the end.

I'm a bit frustrated that the OS can't tell exactly which child has exited, but AFAIK when there's a `Command` no other `Cmd` is spawned.

I have no idea how to write tests for that... and I hope it won't catch grandchildren.