### PR TITLE
Add structured iBazel change notifications

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
 
           - name: darwin_amd64
             artifact: ibazel_darwin_amd64
-            os: macos-13
+            os: macos-15-intel
             build_flags: --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64_cgo
             ext: ""
 
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -55,14 +55,14 @@ jobs:
         run: cp $(bazel info bazel-bin)/cmd/ibazel/ibazel_/ibazel${{ matrix.ext }} ${{ matrix.artifact }}
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.artifact }}
 
       - name: Upload Release Asset
         id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
         if: ${{ github.event.release.upload_url }} 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,11 +79,11 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           path: ./npm-staging/bin
 
@@ -104,7 +104,7 @@ jobs:
           bazel run --config="release" "//release/npm" -- "${PWD}/CONTRIBUTORS" > "npm-staging/package.json"
 
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ your target contains `ibazel_notify_changes` in its `tags` attribute, then the
 command will stay alive and will receive a notification of the source changes on
 stdin.
 
+Targets that additionally contain `ibazel_notify_changes_v1` receive a
+versioned JSON event after each incremental build containing the filesystem
+changes that triggered it. Keep both tags so older iBazel versions still use
+notification mode. Targets without the new tag retain the legacy protocol.
+
+```text
+IBAZEL_BUILD_COMPLETED SUCCESS
+IBAZEL_EVENT {"version":1,"type":"build_completed","success":true,"changes":[{"path":"/workspace/src/app.ts","kind":"source"}]}
+```
+
+`kind` is `source` for source-file changes and `graph` for build-file changes.
+
 ## Output Runner
 
 iBazel is capable of producing and running commands from the output of Bazel

--- a/internal/ibazel/command/command.go
+++ b/internal/ibazel/command/command.go
@@ -46,8 +46,14 @@ type Command interface {
 	Start() (*bytes.Buffer, error)
 	Terminate()
 	Kill()
-	NotifyOfChanges() *bytes.Buffer
+	NotifyOfChanges(changes []Change) *bytes.Buffer
 	IsSubprocessRunning() bool
+}
+
+// Change describes a filesystem change that triggered the current build.
+type Change struct {
+	Path string `json:"path"`
+	Kind string `json:"kind"`
 }
 
 // start will be called by most implementations since this logic is extremely

--- a/internal/ibazel/command/default_command.go
+++ b/internal/ibazel/command/default_command.go
@@ -84,7 +84,7 @@ func (c *defaultCommand) Start() (*bytes.Buffer, error) {
 	return outputBuffer, nil
 }
 
-func (c *defaultCommand) NotifyOfChanges() *bytes.Buffer {
+func (c *defaultCommand) NotifyOfChanges(_ []Change) *bytes.Buffer {
 	c.Terminate()
 	c.Start()
 	return nil

--- a/internal/ibazel/command/default_command_test.go
+++ b/internal/ibazel/command/default_command_test.go
@@ -63,7 +63,7 @@ func TestDefaultCommand(t *testing.T) {
 	}
 
 	// This is synonymous with killing the job so use it to kill the job and test everything.
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	assertKilled(t, toKill.RootProcess())
 }
 

--- a/internal/ibazel/command/notify_command.go
+++ b/internal/ibazel/command/notify_command.go
@@ -16,6 +16,7 @@ package command
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"sync"
@@ -31,17 +32,26 @@ type notifyCommand struct {
 	args        []string
 	pg          process_group.ProcessGroup
 	stdin       io.WriteCloser
+	structured  bool
 	termSync    sync.Once
+}
+
+type buildEvent struct {
+	Version int      `json:"version"`
+	Type    string   `json:"type"`
+	Success bool     `json:"success"`
+	Changes []Change `json:"changes"`
 }
 
 // NotifyCommand is an alternate mode for starting a command. In this mode the
 // command will be notified on stdin that the source files have changed.
-func NotifyCommand(startupArgs []string, bazelArgs []string, target string, args []string) Command {
+func NotifyCommand(startupArgs []string, bazelArgs []string, target string, args []string, structured bool) Command {
 	return &notifyCommand{
 		startupArgs: startupArgs,
 		target:      target,
 		bazelArgs:   bazelArgs,
 		args:        args,
+		structured:  structured,
 	}
 }
 
@@ -91,7 +101,7 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 	return outputBuffer, nil
 }
 
-func (c *notifyCommand) NotifyOfChanges() *bytes.Buffer {
+func (c *notifyCommand) NotifyOfChanges(changes []Change) *bytes.Buffer {
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)
@@ -111,12 +121,14 @@ func (c *notifyCommand) NotifyOfChanges() *bytes.Buffer {
 		if err != nil {
 			log.Errorf("Error writing failure to stdin: %s", err)
 		}
+		c.writeBuildEvent(false, changes)
 	} else {
 		log.Log("IBAZEL BUILD SUCCESS")
 		_, err := c.stdin.Write([]byte("IBAZEL_BUILD_COMPLETED SUCCESS\n"))
 		if err != nil {
 			log.Errorf("Error writing success to stdin: %v", err)
 		}
+		c.writeBuildEvent(true, changes)
 		if !c.IsSubprocessRunning() {
 			log.Log("Restarting process...")
 			c.Terminate()
@@ -124,6 +136,25 @@ func (c *notifyCommand) NotifyOfChanges() *bytes.Buffer {
 		}
 	}
 	return outputBuffer
+}
+
+func (c *notifyCommand) writeBuildEvent(success bool, changes []Change) {
+	if !c.structured {
+		return
+	}
+	event, err := json.Marshal(buildEvent{
+		Version: 1,
+		Type:    "build_completed",
+		Success: success,
+		Changes: changes,
+	})
+	if err != nil {
+		log.Errorf("Error encoding build event: %v", err)
+		return
+	}
+	if _, err := c.stdin.Write(append(append([]byte("IBAZEL_EVENT "), event...), '\n')); err != nil {
+		log.Errorf("Error writing build event to stdin: %v", err)
+	}
 }
 
 func (c *notifyCommand) IsSubprocessRunning() bool {

--- a/internal/ibazel/command/notify_command_test.go
+++ b/internal/ibazel/command/notify_command_test.go
@@ -15,6 +15,7 @@
 package command
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
@@ -23,6 +24,39 @@ import (
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/process_group"
 )
+
+type bufferWriteCloser struct {
+	bytes.Buffer
+}
+
+func (b *bufferWriteCloser) Close() error { return nil }
+
+func TestNotifyCommandStructuredBuildEvent(t *testing.T) {
+	stdin := &bufferWriteCloser{}
+	c := &notifyCommand{stdin: stdin, structured: true}
+	changes := []Change{
+		{Path: "/workspace/frontend/app.tsx", Kind: "source"},
+		{Path: "/workspace/frontend/BUILD", Kind: "graph"},
+	}
+
+	c.writeBuildEvent(true, changes)
+
+	want := "IBAZEL_EVENT {\"version\":1,\"type\":\"build_completed\",\"success\":true,\"changes\":[{\"path\":\"/workspace/frontend/app.tsx\",\"kind\":\"source\"},{\"path\":\"/workspace/frontend/BUILD\",\"kind\":\"graph\"}]}\n"
+	if got := stdin.String(); got != want {
+		t.Errorf("structured build event = %q, want %q", got, want)
+	}
+}
+
+func TestNotifyCommandLegacyProtocolDoesNotWriteBuildEvent(t *testing.T) {
+	stdin := &bufferWriteCloser{}
+	c := &notifyCommand{stdin: stdin}
+
+	c.writeBuildEvent(true, []Change{{Path: "/workspace/app.ts", Kind: "source"}})
+
+	if got := stdin.String(); got != "" {
+		t.Errorf("legacy protocol wrote structured event %q", got)
+	}
+}
 
 func TestNotifyCommand(t *testing.T) {
 	log.SetLogger(t)
@@ -52,11 +86,11 @@ func TestNotifyCommand(t *testing.T) {
 	bazelNew = func() bazel.Bazel { return b }
 	defer func() { bazelNew = oldBazelNew }()
 
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	b.BuildError(errors.New("Demo error"))
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	b.BuildError(nil)
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 
 	b.AssertActions(t, [][]string{
 		{"SetStartupArgs"},
@@ -120,14 +154,14 @@ func TestNotifyCommand_Restart(t *testing.T) {
 		t.Errorf("new subprocess shouldn't have been started yet. State: %v", pg.RootProcess().ProcessState)
 	}
 
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	if c.IsSubprocessRunning() {
 		t.Errorf("process should not start with build errors. State: %v", pg.RootProcess().ProcessState)
 	}
 
 	// Since the process isn't currently running, this should start it.
 	b.BuildError(nil)
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	if !c.IsSubprocessRunning() {
 		t.Errorf("subprocess should have started. State: %v", pg.RootProcess().ProcessState)
 	}
@@ -140,14 +174,14 @@ func TestNotifyCommand_Restart(t *testing.T) {
 	}
 
 	b.BuildError(errors.New("Demo error"))
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	if c.IsSubprocessRunning() {
 		t.Errorf("subprocess should not restart with build errors. State: %v", pg.RootProcess().ProcessState)
 	}
 
 	// Since the process isn't currently running, this should re-start it.
 	b.BuildError(nil)
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	if !c.IsSubprocessRunning() {
 		t.Errorf("subprocess should have been restarted. State: %v", pg.RootProcess().ProcessState)
 	}
@@ -157,7 +191,7 @@ func TestNotifyCommand_Restart(t *testing.T) {
 		t.Error("PIDs of restarted process should be different that original process")
 	}
 
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	if pid2 != c.pg.RootProcess().Process.Pid {
 		t.Error("non-dead process was restarted")
 	}

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -83,6 +83,7 @@ type IBazel struct {
 	filesWatched map[common.Watcher]map[string]struct{} // Inner map is a surrogate for a set
 
 	lifecycleListeners []Lifecycle
+	pendingChanges     []command.Change
 
 	state State
 }
@@ -213,6 +214,17 @@ func (i *IBazel) targetDecider(target string, rule *blaze_query.Rule) {
 }
 
 func (i *IBazel) changeDetected(targets []string, changeType string, change string) {
+	pendingChange := command.Change{Path: change, Kind: changeType}
+	seen := false
+	for _, existing := range i.pendingChanges {
+		if existing == pendingChange {
+			seen = true
+			break
+		}
+	}
+	if !seen {
+		i.pendingChanges = append(i.pendingChanges, pendingChange)
+	}
 	for _, l := range i.lifecycleListeners {
 		l.ChangeDetected(targets, changeType, change)
 	}
@@ -344,6 +356,7 @@ func (i *IBazel) iteration(command string, commandToRun runnableCommand, targets
 		outputBuffer, err := commandToRun(targets...)
 		i.interruptCount = 0
 		i.afterCommand(targets, command, err == nil, outputBuffer)
+		i.pendingChanges = nil
 		i.state = WAIT
 	}
 }
@@ -427,17 +440,21 @@ func (i *IBazel) setupRun(target string) command.Command {
 	i.targetDecider(target, rule)
 
 	commandNotify := false
+	structuredNotify := false
 	for _, attr := range rule.Attribute {
 		if *attr.Name == "tags" && *attr.Type == blaze_query.Attribute_STRING_LIST {
 			if contains(attr.StringListValue, "ibazel_notify_changes") {
 				commandNotify = true
+			}
+			if contains(attr.StringListValue, "ibazel_notify_changes_v1") {
+				structuredNotify = true
 			}
 		}
 	}
 
 	if commandNotify {
 		log.Logf("Launching with notifications")
-		return commandNotifyCommand(i.startupArgs, i.bazelArgs, target, i.args)
+		return commandNotifyCommand(i.startupArgs, i.bazelArgs, target, i.args, structuredNotify)
 	} else {
 		return commandDefaultCommand(i.startupArgs, i.bazelArgs, target, i.args)
 	}
@@ -456,7 +473,7 @@ func (i *IBazel) run(targets ...string) (*bytes.Buffer, error) {
 	}
 
 	log.Logf("Notifying of changes")
-	outputBuffer := i.cmd.NotifyOfChanges()
+	outputBuffer := i.cmd.NotifyOfChanges(i.pendingChanges)
 	return outputBuffer, nil
 }
 

--- a/internal/ibazel/ibazel_test.go
+++ b/internal/ibazel/ibazel_test.go
@@ -84,6 +84,7 @@ type mockCommand struct {
 	args        []string
 
 	notifiedOfChanges bool
+	changes           []command.Change
 	started           bool
 	terminated        bool
 
@@ -99,8 +100,9 @@ func (m *mockCommand) Start() (*bytes.Buffer, error) {
 	m.started = true
 	return nil, nil
 }
-func (m *mockCommand) NotifyOfChanges() *bytes.Buffer {
+func (m *mockCommand) NotifyOfChanges(changes []command.Change) *bytes.Buffer {
 	m.notifiedOfChanges = true
+	m.changes = changes
 	return nil
 }
 func (m *mockCommand) Terminate() {
@@ -438,6 +440,7 @@ func TestIBazelRun_notifyPreexistiingJobWhenStarting(t *testing.T) {
 		notifiedOfChanges: false,
 	}
 	i.cmd = cmd
+	i.pendingChanges = []command.Change{{Path: "/workspace/path/to/file", Kind: "source"}}
 
 	path := "//path/to:target"
 	i.run(path)
@@ -445,6 +448,66 @@ func TestIBazelRun_notifyPreexistiingJobWhenStarting(t *testing.T) {
 	if !cmd.notifiedOfChanges {
 		t.Errorf("The previously running command was not notified of changes")
 	}
+	assertEqual(t, i.pendingChanges, cmd.changes, "Changes passed to running command")
+}
+
+func TestSetupRunNegotiatesStructuredNotifications(t *testing.T) {
+	oldCommandNotifyCommand := commandNotifyCommand
+	defer func() { commandNotifyCommand = oldCommandNotifyCommand }()
+
+	for _, test := range []struct {
+		name       string
+		tags       []string
+		structured bool
+	}{
+		{name: "legacy", tags: []string{"ibazel_notify_changes"}},
+		{name: "structured", tags: []string{"ibazel_notify_changes", "ibazel_notify_changes_v1"}, structured: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			i, mockBazel := newIBazel(t)
+			defer i.Cleanup()
+
+			target := "//path/to:target"
+			attributeType := blaze_query.Attribute_STRING_LIST
+			mockBazel.AddCQueryResponse(target, &analysispb.CqueryResult{
+				Results: []*analysispb.ConfiguredTarget{{
+					Target: &blaze_query.Target{
+						Type: blaze_query.Target_RULE.Enum(),
+						Rule: &blaze_query.Rule{
+							Name: proto.String(target),
+							Attribute: []*blaze_query.Attribute{{
+								Name:            proto.String("tags"),
+								Type:            &attributeType,
+								StringListValue: test.tags,
+							}},
+						},
+					},
+				}},
+			})
+
+			var structured bool
+			commandNotifyCommand = func(_ []string, _ []string, _ string, _ []string, enabled bool) command.Command {
+				structured = enabled
+				return &mockCommand{}
+			}
+
+			i.setupRun(target)
+			assertEqual(t, test.structured, structured, "Structured notification mode")
+		})
+	}
+}
+
+func TestChangeDetectedRecordsUniqueChanges(t *testing.T) {
+	i := &IBazel{}
+	i.changeDetected(nil, "source", "/workspace/path/to/file")
+	i.changeDetected(nil, "source", "/workspace/path/to/file")
+	i.changeDetected(nil, "graph", "/workspace/path/to/BUILD")
+
+	want := []command.Change{
+		{Path: "/workspace/path/to/file", Kind: "source"},
+		{Path: "/workspace/path/to/BUILD", Kind: "graph"},
+	}
+	assertEqual(t, want, i.pendingChanges, "Unique changes for the current iteration")
 }
 
 func TestHandleSignals_SIGINTWithoutRunningCommand(t *testing.T) {


### PR DESCRIPTION
## Why

Notification-mode targets only receive global build-started and build-completed lines. Supervisors therefore cannot tell which filesystem changes triggered an incremental build or selectively react to them.

## What changed

- Batch and deduplicate source and build-graph changes for each iteration.
- Add the opt-in `ibazel_notify_changes_v1` capability tag while preserving the legacy protocol for existing targets.
- Emit a versioned `IBAZEL_EVENT` JSON line after build completion with the result and triggering paths.
- Document the protocol and compatibility contract.

Consumers should keep `ibazel_notify_changes` alongside the v1 tag so older iBazel versions continue using notification mode.

## Verification

Ran patched iBazel against a protocol-aware multirun target and confirmed both children received the exact touched source path after the legacy success notification.