### PR TITLE
Support multiple FSEvents watch roots

### DIFF
--- a/internal/e2e/local_repository/local_repository_test.go
+++ b/internal/e2e/local_repository/local_repository_test.go
@@ -3,10 +3,11 @@ package simple
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,6 +59,24 @@ var (
 	secondaryWd2 string
 )
 
+func createSecondaryWorkspace(wd string) error {
+	if err := os.Mkdir(wd, 0777); err != nil {
+		return fmt.Errorf("os.Mkdir(%q): %w", wd, err)
+	}
+	for file, contents := range map[string]string{
+		".bazelversion": "6.5.0",
+		"BUILD.bazel":   secondaryBuild,
+		"lib.sh":        secondaryLib,
+		"WORKSPACE":     "",
+		"MODULE.bazel":  "",
+	} {
+		if err := ioutil.WriteFile(filepath.Join(wd, file), []byte(contents), 0777); err != nil {
+			return fmt.Errorf("failed to write file %q: %w", file, err)
+		}
+	}
+	return nil
+}
+
 func TestMain(m *testing.M) {
 	e2e.TestMain(m, e2e.Args{
 		Main: mainFiles,
@@ -66,21 +85,9 @@ func TestMain(m *testing.M) {
 			secondaryWd, _ = filepath.Abs(filepath.Join("..", "secondary"))
 			secondaryWd2, _ = filepath.Abs(filepath.Join("..", "secondary-2"))
 
-			// Manually create files in the secondary workspaces.
 			for _, wd := range []string{secondaryWd, secondaryWd2} {
-				if err := os.Mkdir(wd, 0777); err != nil {
-					log.Fatalf("os.Mkdir(%q): %v", wd, err)
-				}
-				for file, contents := range map[string]string{
-					".bazelversion": "6.5.0",
-					"BUILD.bazel": secondaryBuild,
-					"lib.sh":      secondaryLib,
-					"WORKSPACE":   "",
-					"MODULE.bazel":   "",
-				} {
-					if err := ioutil.WriteFile(filepath.Join(wd, file), []byte(contents), 0777); err != nil {
-						log.Fatalf("Failed to write file %q: %v", file, err)
-					}
+				if err := createSecondaryWorkspace(wd); err != nil {
+					return err
 				}
 			}
 			return nil
@@ -97,7 +104,7 @@ func TestRunWithModifiedFile(t *testing.T) {
 	ibazel.Run([]string{}, "//:test")
 	defer ibazel.Kill()
 
-	ibazel.ExpectOutput("hello!", 50 * time.Second)
+	ibazel.ExpectOutput("hello!", 50*time.Second)
 
 	ioutil.WriteFile(
 		filepath.Join(secondaryWd, "lib.sh"), []byte(secondaryLibAlt), 0777)
@@ -117,5 +124,50 @@ func TestRunWithRepositoryOverrideModifiedFile(t *testing.T) {
 
 	ioutil.WriteFile(
 		filepath.Join(secondaryWd2, "lib.sh"), []byte(secondaryLibAlt), 0777)
+	ibazel.ExpectOutput("hello2!")
+}
+
+func TestRunWithDisjointRepositoryOverrideModifiedFile(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("FSEvents is only used on macOS")
+	}
+
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repositoryRoot, err := os.MkdirTemp(currentUser.HomeDir, "ibazel-disjoint-root-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(repositoryRoot) })
+
+	disjointRepository := filepath.Join(repositoryRoot, "secondary")
+	if err := createSecondaryWorkspace(disjointRepository); err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err = filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaceRoot := strings.Split(strings.Trim(workspace, "/"), "/")[0]
+	repositoryTopLevel := strings.Split(strings.Trim(disjointRepository, "/"), "/")[0]
+	if workspaceRoot == repositoryTopLevel {
+		t.Fatalf("test paths share top-level directory %q", workspaceRoot)
+	}
+
+	ibazel := e2e.SetUp(t)
+	ibazel.Run([]string{fmt.Sprintf("--override_repository=secondary=%s", disjointRepository)}, "//:test")
+	defer ibazel.Kill()
+
+	ibazel.ExpectOutput("hello!", 50*time.Second)
+
+	if err := ioutil.WriteFile(filepath.Join(disjointRepository, "lib.sh"), []byte(secondaryLibAlt), 0777); err != nil {
+		t.Fatal(err)
+	}
 	ibazel.ExpectOutput("hello2!")
 }

--- a/internal/ibazel/fswatcher/fsevents/fsevents.go
+++ b/internal/ibazel/fswatcher/fsevents/fsevents.go
@@ -18,8 +18,8 @@
 package fsevents
 
 import (
-	"errors"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/fsnotify/fsevents"
@@ -45,13 +45,9 @@ func (w *realFSEventsWatcher) Close() error {
 // UpdateAll implements ibazel/fswatcher/common.Watcher
 func (w *realFSEventsWatcher) UpdateAll(names []string) error {
 	w.es.Stop()
-	commonRoot, err := findCommonRoot(names)
-	if err != nil {
-		return err
-	}
 	es := &fsevents.EventStream{
 		Events: make(chan []fsevents.Event),
-		Paths:  commonRoot,
+		Paths:  findCommonRoots(names),
 		Flags:  w.es.Flags,
 	}
 	w.es = es
@@ -104,32 +100,41 @@ func newEvent(name string, mask fsevents.EventFlags) (common.Event, bool) {
 	return e, true
 }
 
-// Find the longest common root path of all directories to watch.
-func findCommonRoot(names []string) ([]string, error) {
+// FSEvents recursively watches each path but accepts at most 4096 paths. Collapse
+// each top-level tree independently without requiring every path to share one root.
+func findCommonRoots(names []string) []string {
 	if len(names) == 0 {
-		return []string{}, nil
+		return []string{}
 	}
 
-	rootSplit := strings.Split(strings.Trim(names[0], "/"), "/")
-	rootLength := len(rootSplit)
-
-	for _, dir := range names {
-		split := strings.Split(strings.Trim(dir, "/"), "/")
-		commonLength := 0
-		for i := 0; i < rootLength && i < len(split); i++ {
-			if rootSplit[i] != split[i] {
-				break
-			}
-			commonLength = i + 1
+	directoriesByRoot := make(map[string][][]string)
+	for _, name := range names {
+		trimmed := strings.Trim(name, "/")
+		if trimmed == "" {
+			return []string{"/"}
 		}
-		rootLength = commonLength
+		split := strings.Split(trimmed, "/")
+		directoriesByRoot[split[0]] = append(directoriesByRoot[split[0]], split)
 	}
 
-	if rootLength == 0 {
-		return nil, errors.New("could not find common root of directories")
+	roots := make([]string, 0, len(directoriesByRoot))
+	for _, directories := range directoriesByRoot {
+		rootLength := len(directories[0])
+		for _, directory := range directories[1:] {
+			commonLength := 0
+			for i := 0; i < rootLength && i < len(directory); i++ {
+				if directories[0][i] != directory[i] {
+					break
+				}
+				commonLength = i + 1
+			}
+			rootLength = commonLength
+		}
+		roots = append(roots, "/"+filepath.Join(directories[0][:rootLength]...)+"/")
 	}
 
-	return []string{"/" + filepath.Join(rootSplit[:rootLength]...) + "/"}, nil
+	sort.Strings(roots)
+	return roots
 }
 
 func NewWatcher() (common.Watcher, error) {

--- a/internal/ibazel/fswatcher/fsevents/fsevents_test.go
+++ b/internal/ibazel/fswatcher/fsevents/fsevents_test.go
@@ -18,11 +18,12 @@
 package fsevents
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestFindCommonRoot(t *testing.T) {
+func TestFindCommonRoots(t *testing.T) {
 	tests := []struct {
 		in   []string
 		want []string
@@ -34,6 +35,21 @@ func TestFindCommonRoot(t *testing.T) {
 				"/a/d/",
 			},
 			[]string{"/a/"},
+		},
+		// Finds independent roots instead of watching the filesystem root.
+		{
+			[]string{
+				"/a/b/c/",
+				"/a/d/",
+				"/b/e/",
+				"/b/f/",
+			},
+			[]string{"/a/", "/b/"},
+		},
+		// The filesystem root covers every other path.
+		{
+			[]string{"/", "/a/b/"},
+			[]string{"/"},
 		},
 		// Finds common sub-root of multiple recursive directories
 		{
@@ -59,19 +75,9 @@ func TestFindCommonRoot(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		got, err := findCommonRoot(test.in)
-		if err != nil {
-			t.Errorf("unexpected error %v", err.Error())
-		}
+		got := findCommonRoots(test.in)
 		if diff := cmp.Diff(got, test.want); diff != "" {
-			t.Errorf("findCommonRoot diff (-got,+want):\n%s", diff)
+			t.Errorf("findCommonRoots diff (-got,+want):\n%s", diff)
 		}
-	}
-}
-
-func TestNoCommonRootError(t *testing.T) {
-	_, err := findCommonRoot([]string{"/a/", "/b/"})
-	if err == nil {
-		t.Error("expected error when there is no common root")
 	}
 }


### PR DESCRIPTION
## Summary

On macOS, iBazel collapsed every watched directory into one FSEvents root. When a workspace and a local or overridden repository lived under different top-level directories, no common root existed, so updating the watch list failed.

Group watched directories by top-level tree and compute one recursive watch root per group. This preserves the existing protection against FSEvents' 4,096-path limit without falling back to watching `/`.

Add a Darwin E2E with the Bazel workspace under `/private` and an overridden repository under `/Users`; changing the external source must trigger another run.

Fixes #819.

## Test

- `bazel test //... --test_output=errors`
