### PR TITLE
Start notification-mode runs before watch discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ versioned JSON event after each incremental build containing the filesystem
 changes that triggered it. Keep both tags so older iBazel versions still use
 notification mode. Targets without the new tag retain the legacy protocol.
 
+Notification-mode targets start before iBazel discovers their watch graph.
+iBazel installs the watchers afterward and sends a catch-up build, keeping a
+large watch query off the application's startup path without missing changes.
+
 ```text
 IBAZEL_BUILD_COMPLETED SUCCESS
 IBAZEL_EVENT {"version":1,"type":"build_completed","success":true,"changes":[{"path":"/workspace/src/app.ts","kind":"source"}]}

--- a/internal/e2e/simple/simple_test.go
+++ b/internal/e2e/simple/simple_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -19,6 +20,18 @@ const mainFiles = `
 sh_binary(
   name = "simple",
   srcs = ["simple.sh"],
+)
+
+sh_binary(
+  name = "notify",
+  srcs = ["notify.sh"],
+  tags = ["ibazel_notify_changes"],
+)
+
+sh_binary(
+  name = "structured_notify",
+  srcs = ["structured_notify.sh"],
+  tags = ["ibazel_notify_changes", "ibazel_notify_changes_v1"],
 )
 
 # Test and Coverage base case test
@@ -52,6 +65,16 @@ sh_binary(
 )
 -- simple.sh --
 printf "Started!"
+-- notify.sh --
+echo "notify started"
+while IFS= read -r event; do
+  printf 'notify received: %s\n' "$event"
+done
+-- structured_notify.sh --
+echo "structured notify started"
+while IFS= read -r event; do
+  printf 'structured notify received: %s\n' "$event"
+done
 -- environment.sh --
 printf "Started and IBAZEL=${IBAZEL}!"
 -- define_test_1.sh --
@@ -84,7 +107,45 @@ func TestSimpleBuild(t *testing.T) {
 	ibazel.Run([]string{}, "//:simple")
 	defer ibazel.Kill()
 
-	ibazel.ExpectOutput("Started!", 50 * time.Second)
+	ibazel.ExpectOutput("Started!", 50*time.Second)
+}
+
+func TestNotificationRunStartsBeforeWatchDiscovery(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		target string
+		output string
+	}{
+		{name: "legacy", target: "//:notify", output: "notify"},
+		{name: "structured", target: "//:structured_notify", output: "structured notify"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ibazel := e2e.SetUp(t)
+			ibazel.Run([]string{}, test.target)
+			defer ibazel.Kill()
+
+			output := test.output + " started(?s:.*)" + test.output + " received: IBAZEL_BUILD_COMPLETED SUCCESS"
+			if test.name == "structured" {
+				output += `(?s:.*)IBAZEL_EVENT .*"changes":\[\{"path":"","kind":"graph"\}\]`
+			}
+			ibazel.ExpectOutput(output)
+
+			log := ibazel.GetIBazelError()
+			run := strings.Index(log, "Running "+test.target)
+			query := strings.Index(log, "Querying for files to watch...")
+			if run == -1 || query == -1 || run > query {
+				t.Fatalf("expected target to start before watch discovery; log:\n%s", log)
+			}
+
+			if test.name == "structured" {
+				e2e.MustWriteFile(t, "structured_notify.sh", `echo "structured notify restarted"
+while IFS= read -r event; do
+  printf 'structured notify received: %s\n' "$event"
+done`)
+				ibazel.ExpectOutput(`IBAZEL_EVENT .*"kind":"source"`)
+			}
+		})
+	}
 }
 
 func TestSimpleTestFailing(t *testing.T) {

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -200,18 +200,9 @@ func (i *IBazel) Cleanup() {
 
 func (i *IBazel) targetDecider(target string, rule *blaze_query.Rule) {
 	for _, l := range i.lifecycleListeners {
-		// TODO: As the name implies, it would be good to use this to make a
-		// determination about if future events should be routed to this listener.
-		// Why not do it now?
-		// Right now I don't track which file is associated with the end target. I
-		// just query for a list of all files that are rdeps of any target that is
-		// in the list of targets to build/test/run (although run can only have 1).
-		// Since I don't have that mapping right now the information doesn't
-		// presently exist to implement this properly. Additionally, since querying
-		// is currently in the critical path for getting something the user cares
-		// about on screen, I'm not sure that it is wise to do this in the first
-		// pass. It might be worth triggering the user action, launching their thing
-		// and then running a background thread to access the data.
+		// TODO: Use a target-to-file mapping to decide which listeners receive
+		// future events. Watch queries currently return the union of files for all
+		// requested targets and discard that ownership information.
 		l.TargetDecider(rule)
 	}
 }

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -84,6 +84,9 @@ type IBazel struct {
 
 	lifecycleListeners []Lifecycle
 	pendingChanges     []command.Change
+	runCommandNotifies bool
+	runCommandStarted  bool
+	queryAfterRun      bool
 
 	state State
 }
@@ -263,28 +266,28 @@ func (i *IBazel) setup() error {
 // Run the specified target (singular) in the IBazel loop.
 func (i *IBazel) Run(target string, args []string) error {
 	i.args = args
-	return i.loop("run", i.run, []string{target})
+	return i.loop("run", i.run, []string{target}, i.prepareRun(target))
 }
 
 // Build the specified targets in the IBazel loop.
 func (i *IBazel) Build(targets ...string) error {
-	return i.loop("build", i.build, targets)
+	return i.loop("build", i.build, targets, QUERY)
 }
 
 // Test the specified targets in the IBazel loop.
 func (i *IBazel) Test(targets ...string) error {
-	return i.loop("test", i.test, targets)
+	return i.loop("test", i.test, targets, QUERY)
 }
 
 // Get code coverage for the specified targets in the IBazel loop.
 func (i *IBazel) Coverage(targets ...string) error {
-	return i.loop("coverage", i.test, targets)
+	return i.loop("coverage", i.test, targets, QUERY)
 }
 
-func (i *IBazel) loop(command string, commandToRun runnableCommand, targets []string) error {
+func (i *IBazel) loop(command string, commandToRun runnableCommand, targets []string, initialState State) error {
 	joinedTargets := strings.Join(targets, " ")
 
-	i.state = QUERY
+	i.state = initialState
 	for {
 		i.iteration(command, commandToRun, targets, joinedTargets)
 	}
@@ -294,7 +297,7 @@ func (i *IBazel) loop(command string, commandToRun runnableCommand, targets []st
 // to avoid triggering builds on file accesses (e.g. due to your IDE checking modified status).
 const modifyingEvents = common.Write | common.Create | common.Rename | common.Remove
 
-func (i *IBazel) iteration(command string, commandToRun runnableCommand, targets []string, joinedTargets string) {
+func (i *IBazel) iteration(commandName string, commandToRun runnableCommand, targets []string, joinedTargets string) {
 	switch i.state {
 	case WAIT:
 		select {
@@ -351,12 +354,20 @@ func (i *IBazel) iteration(command string, commandToRun runnableCommand, targets
 			i.state = RUN
 		}
 	case RUN:
-		log.Logf("%s %s", strings.Title(verb(command)), joinedTargets)
-		i.beforeCommand(targets, command)
+		log.Logf("%s %s", strings.Title(verb(commandName)), joinedTargets)
+		i.beforeCommand(targets, commandName)
 		outputBuffer, err := commandToRun(targets...)
 		i.interruptCount = 0
-		i.afterCommand(targets, command, err == nil, outputBuffer)
+		i.afterCommand(targets, commandName, err == nil, outputBuffer)
 		i.pendingChanges = nil
+		if i.queryAfterRun {
+			// Notification-mode targets stay alive across builds, so start them before
+			// watch discovery. A full catch-up build closes the unwatched startup window.
+			i.queryAfterRun = false
+			i.pendingChanges = []command.Change{{Kind: "graph"}}
+			i.state = QUERY
+			return
+		}
 		i.state = WAIT
 	}
 }
@@ -453,19 +464,33 @@ func (i *IBazel) setupRun(target string) command.Command {
 	}
 
 	if commandNotify {
+		i.runCommandNotifies = true
 		log.Logf("Launching with notifications")
 		return commandNotifyCommand(i.startupArgs, i.bazelArgs, target, i.args, structuredNotify)
 	} else {
+		i.runCommandNotifies = false
 		return commandDefaultCommand(i.startupArgs, i.bazelArgs, target, i.args)
 	}
 }
 
+func (i *IBazel) prepareRun(target string) State {
+	i.cmd = i.setupRun(target)
+	i.runCommandStarted = false
+	i.queryAfterRun = i.runCommandNotifies
+	if i.runCommandNotifies {
+		return RUN
+	}
+	return QUERY
+}
+
 func (i *IBazel) run(targets ...string) (*bytes.Buffer, error) {
-	if i.cmd == nil {
-		// If the command is empty, we are in our first pass through the state
-		// machine and we need to make a command object.
-		i.cmd = i.setupRun(targets[0])
+	if !i.runCommandStarted {
+		// Direct callers may not have prepared the command through Run.
+		if i.cmd == nil {
+			i.cmd = i.setupRun(targets[0])
+		}
 		outputBuffer, err := i.cmd.Start()
+		i.runCommandStarted = err == nil
 		if err != nil {
 			log.Errorf("Run start failed %v", err)
 		}

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -49,6 +49,7 @@ var exitMessages = map[os.Signal]string{
 }
 
 type State string
+type executionMode int
 type runnableCommand func(...string) (*bytes.Buffer, error)
 
 const (
@@ -58,6 +59,13 @@ const (
 	DEBOUNCE_RUN   State = "DEBOUNCE_RUN"
 	RUN            State = "RUN"
 	QUIT           State = "QUIT"
+)
+
+const (
+	defaultExecution executionMode = iota
+	defaultStartupExecution
+	notificationStartupExecution
+	notificationExecution
 )
 
 const sourceQuery = "kind('source file', deps(set(%s)))"
@@ -84,9 +92,7 @@ type IBazel struct {
 
 	lifecycleListeners []Lifecycle
 	pendingChanges     []command.Change
-	runCommandNotifies bool
-	runCommandStarted  bool
-	queryAfterRun      bool
+	executionMode      executionMode
 
 	state State
 }
@@ -257,28 +263,31 @@ func (i *IBazel) setup() error {
 // Run the specified target (singular) in the IBazel loop.
 func (i *IBazel) Run(target string, args []string) error {
 	i.args = args
-	return i.loop("run", i.run, []string{target}, i.prepareRun(target))
+	i.prepareRun(target)
+	return i.loop("run", i.run, []string{target})
 }
 
 // Build the specified targets in the IBazel loop.
 func (i *IBazel) Build(targets ...string) error {
-	return i.loop("build", i.build, targets, QUERY)
+	i.state = QUERY
+	return i.loop("build", i.build, targets)
 }
 
 // Test the specified targets in the IBazel loop.
 func (i *IBazel) Test(targets ...string) error {
-	return i.loop("test", i.test, targets, QUERY)
+	i.state = QUERY
+	return i.loop("test", i.test, targets)
 }
 
 // Get code coverage for the specified targets in the IBazel loop.
 func (i *IBazel) Coverage(targets ...string) error {
-	return i.loop("coverage", i.test, targets, QUERY)
+	i.state = QUERY
+	return i.loop("coverage", i.test, targets)
 }
 
-func (i *IBazel) loop(command string, commandToRun runnableCommand, targets []string, initialState State) error {
+func (i *IBazel) loop(command string, commandToRun runnableCommand, targets []string) error {
 	joinedTargets := strings.Join(targets, " ")
 
-	i.state = initialState
 	for {
 		i.iteration(command, commandToRun, targets, joinedTargets)
 	}
@@ -351,15 +360,16 @@ func (i *IBazel) iteration(commandName string, commandToRun runnableCommand, tar
 		i.interruptCount = 0
 		i.afterCommand(targets, commandName, err == nil, outputBuffer)
 		i.pendingChanges = nil
-		if i.queryAfterRun {
+		switch i.executionMode {
+		case notificationStartupExecution:
 			// Notification-mode targets stay alive across builds, so start them before
 			// watch discovery. A full catch-up build closes the unwatched startup window.
-			i.queryAfterRun = false
+			i.executionMode = notificationExecution
 			i.pendingChanges = []command.Change{{Kind: "graph"}}
 			i.state = QUERY
-			return
+		default:
+			i.state = WAIT
 		}
-		i.state = WAIT
 	}
 }
 
@@ -455,42 +465,44 @@ func (i *IBazel) setupRun(target string) command.Command {
 	}
 
 	if commandNotify {
-		i.runCommandNotifies = true
+		i.executionMode = notificationStartupExecution
 		log.Logf("Launching with notifications")
 		return commandNotifyCommand(i.startupArgs, i.bazelArgs, target, i.args, structuredNotify)
 	} else {
-		i.runCommandNotifies = false
+		i.executionMode = defaultStartupExecution
 		return commandDefaultCommand(i.startupArgs, i.bazelArgs, target, i.args)
 	}
 }
 
-func (i *IBazel) prepareRun(target string) State {
+func (i *IBazel) prepareRun(target string) {
 	i.cmd = i.setupRun(target)
-	i.runCommandStarted = false
-	i.queryAfterRun = i.runCommandNotifies
-	if i.runCommandNotifies {
-		return RUN
+	switch i.executionMode {
+	case notificationStartupExecution:
+		i.state = RUN
+	default:
+		i.state = QUERY
 	}
-	return QUERY
 }
 
 func (i *IBazel) run(targets ...string) (*bytes.Buffer, error) {
-	if !i.runCommandStarted {
-		// Direct callers may not have prepared the command through Run.
-		if i.cmd == nil {
-			i.cmd = i.setupRun(targets[0])
-		}
-		outputBuffer, err := i.cmd.Start()
-		i.runCommandStarted = err == nil
-		if err != nil {
-			log.Errorf("Run start failed %v", err)
-		}
-		return outputBuffer, err
+	if i.cmd == nil {
+		i.cmd = i.setupRun(targets[0])
 	}
 
-	log.Logf("Notifying of changes")
-	outputBuffer := i.cmd.NotifyOfChanges(i.pendingChanges)
-	return outputBuffer, nil
+	switch i.executionMode {
+	case defaultStartupExecution, notificationStartupExecution:
+		outputBuffer, err := i.cmd.Start()
+		if err != nil {
+			log.Errorf("Run start failed %v", err)
+		} else if i.executionMode == defaultStartupExecution {
+			i.executionMode = defaultExecution
+		}
+		return outputBuffer, err
+	default:
+		log.Logf("Notifying of changes")
+		outputBuffer := i.cmd.NotifyOfChanges(i.pendingChanges)
+		return outputBuffer, nil
+	}
 }
 
 func (i *IBazel) queryRule(rule string) (*blaze_query.Rule, error) {

--- a/internal/ibazel/ibazel_test.go
+++ b/internal/ibazel/ibazel_test.go
@@ -440,7 +440,6 @@ func TestIBazelRun_notifyPreexistiingJobWhenStarting(t *testing.T) {
 		notifiedOfChanges: false,
 	}
 	i.cmd = cmd
-	i.runCommandStarted = true
 	i.pendingChanges = []command.Change{{Path: "/workspace/path/to/file", Kind: "source"}}
 
 	path := "//path/to:target"
@@ -496,7 +495,7 @@ func TestIBazelRunStartsBeforeWatchQuery(t *testing.T) {
 		return cmd
 	}
 
-	i.state = i.prepareRun(target)
+	i.prepareRun(target)
 	i.iteration("run", i.run, []string{target}, target)
 	if !cmd.started {
 		t.Fatal("run target was not started")
@@ -556,9 +555,9 @@ func TestPrepareRunNegotiatesNotificationsAndInitialState(t *testing.T) {
 				return &mockCommand{}
 			}
 
-			initialState := i.prepareRun(target)
+			i.prepareRun(target)
 			assertEqual(t, test.structured, structured, "Structured notification mode")
-			assertEqual(t, test.initialState, initialState, "Initial run state")
+			assertEqual(t, test.initialState, i.state, "Initial run state")
 		})
 	}
 }

--- a/internal/ibazel/ibazel_test.go
+++ b/internal/ibazel/ibazel_test.go
@@ -440,6 +440,7 @@ func TestIBazelRun_notifyPreexistiingJobWhenStarting(t *testing.T) {
 		notifiedOfChanges: false,
 	}
 	i.cmd = cmd
+	i.runCommandStarted = true
 	i.pendingChanges = []command.Change{{Path: "/workspace/path/to/file", Kind: "source"}}
 
 	path := "//path/to:target"
@@ -451,17 +452,81 @@ func TestIBazelRun_notifyPreexistiingJobWhenStarting(t *testing.T) {
 	assertEqual(t, i.pendingChanges, cmd.changes, "Changes passed to running command")
 }
 
-func TestSetupRunNegotiatesStructuredNotifications(t *testing.T) {
+func TestIBazelRunStartsBeforeWatchQuery(t *testing.T) {
+	log.SetTesting(t)
+
+	oldCommandNotifyCommand := commandNotifyCommand
+	defer func() { commandNotifyCommand = oldCommandNotifyCommand }()
+
+	i, mockBazel := newIBazel(t)
+	defer i.Cleanup()
+
+	target := "//path/to:target"
+	attributeType := blaze_query.Attribute_STRING_LIST
+	mockBazel.AddCQueryResponse(target, &analysispb.CqueryResult{
+		Results: []*analysispb.ConfiguredTarget{{
+			Target: &blaze_query.Target{
+				Type: blaze_query.Target_RULE.Enum(),
+				Rule: &blaze_query.Rule{
+					Name: proto.String(target),
+					Attribute: []*blaze_query.Attribute{{
+						Name:            proto.String("tags"),
+						Type:            &attributeType,
+						StringListValue: []string{"ibazel_notify_changes"},
+					}},
+				},
+			},
+		}},
+	})
+	mockBazel.AddCQueryResponse(fmt.Sprintf("deps(set(%s))", target), &analysispb.CqueryResult{})
+	mockBazel.AddQueryResponse("buildfiles(set())", &blaze_query.QueryResult{})
+	mockBazel.AddCQueryResponse(fmt.Sprintf("kind('source file', deps(set(%s)))", target), &analysispb.CqueryResult{})
+
+	outputBase := t.TempDir()
+	if err := os.Mkdir(filepath.Join(outputBase, "external"), 0o700); err != nil {
+		t.Fatalf("failed to create external directory: %v", err)
+	}
+	mockBazel.SetInfo(map[string]string{
+		"output_base":  outputBase,
+		"install_base": t.TempDir(),
+	})
+
+	cmd := &mockCommand{}
+	commandNotifyCommand = func(_ []string, _ []string, _ string, _ []string, _ bool) command.Command {
+		return cmd
+	}
+
+	i.state = i.prepareRun(target)
+	i.iteration("run", i.run, []string{target}, target)
+	if !cmd.started {
+		t.Fatal("run target was not started")
+	}
+	assertEqual(t, QUERY, i.state, "Watch query should run after the target starts")
+
+	i.iteration("run", i.run, []string{target}, target)
+	assertEqual(t, RUN, i.state, "Catch-up build should follow the watch query")
+
+	i.iteration("run", i.run, []string{target}, target)
+	if !cmd.notifiedOfChanges {
+		t.Fatal("run target did not receive the catch-up build")
+	}
+	assertEqual(t, []command.Change{{Kind: "graph"}}, cmd.changes, "Catch-up build changes")
+	assertEqual(t, WAIT, i.state, "Run should wait after the catch-up build")
+}
+
+func TestPrepareRunNegotiatesNotificationsAndInitialState(t *testing.T) {
 	oldCommandNotifyCommand := commandNotifyCommand
 	defer func() { commandNotifyCommand = oldCommandNotifyCommand }()
 
 	for _, test := range []struct {
-		name       string
-		tags       []string
-		structured bool
+		name         string
+		tags         []string
+		structured   bool
+		initialState State
 	}{
-		{name: "legacy", tags: []string{"ibazel_notify_changes"}},
-		{name: "structured", tags: []string{"ibazel_notify_changes", "ibazel_notify_changes_v1"}, structured: true},
+		{name: "default", initialState: QUERY},
+		{name: "legacy", tags: []string{"ibazel_notify_changes"}, initialState: RUN},
+		{name: "structured", tags: []string{"ibazel_notify_changes", "ibazel_notify_changes_v1"}, structured: true, initialState: RUN},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			i, mockBazel := newIBazel(t)
@@ -491,8 +556,9 @@ func TestSetupRunNegotiatesStructuredNotifications(t *testing.T) {
 				return &mockCommand{}
 			}
 
-			i.setupRun(target)
+			initialState := i.prepareRun(target)
 			assertEqual(t, test.structured, structured, "Structured notification mode")
+			assertEqual(t, test.initialState, initialState, "Initial run state")
 		})
 	}
 }


### PR DESCRIPTION
## Why

`ibazel run` discovers the full transitive watch graph before starting the target. In large workspaces, this can delay a notification-mode dev server by tens of seconds even though the process can stay alive while iBazel installs watchers.

## What

- inspect the target tags up front, then start `ibazel_notify_changes` targets before full watch discovery
- install watchers after startup and send a synthetic graph change for a catch-up build
- support both legacy and v1 notification protocols
- preserve query-first behavior for restart-mode targets, builds, tests, and coverage

## Verification

The notification example served before watch discovery completed, received the catch-up build without restarting, then rebuilt normally after a source edit.
