### PR TITLE
Emit BEP output groups in structured notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ IBAZEL_EVENT {"version":1,"type":"build_completed","success":true,"changes":[{"p
 
 `kind` is `source` for source-file changes and `graph` for build-file changes.
 
+For notification-mode targets with direct rule dependencies, iBazel preserves
+ownership from the post-start configured dependency query. Events include the
+direct targets whose dependency graphs contain the changed files:
+
+```text
+IBAZEL_EVENT {"version":1,"type":"build_completed","success":true,"changes":[{"path":"/workspace/rpc/main.rs","kind":"source"}],"affected_targets":["//app:rpc"],"affected_targets_complete":true}
+```
+
+Consumers may update only listed target workloads when
+`affected_targets_complete` is true. When it is absent, ownership was
+unavailable for at least one change and consumers should use their safe
+fallback. This uses the same post-start cquery that discovers watched files; it
+does not enable Bazel's all-action BEP stream.
+
 Structured notification targets may request Bazel output groups with
 `--notify_output_groups`. iBazel adds those groups to each build and reads them
 from Bazel's Build Event Protocol. Successful events include the complete,

--- a/README.md
+++ b/README.md
@@ -87,6 +87,23 @@ IBAZEL_EVENT {"version":1,"type":"build_completed","success":true,"changes":[{"p
 
 `kind` is `source` for source-file changes and `graph` for build-file changes.
 
+Structured notification targets may request Bazel output groups with
+`--notify_output_groups`. iBazel adds those groups to each build and reads them
+from Bazel's Build Event Protocol. Successful events include the complete,
+deduplicated artifact set for each requested group:
+
+```text
+ibazel --notify_output_groups=generated,manifest run //app:dev
+
+IBAZEL_EVENT {"version":1,"type":"build_completed","success":true,"changes":[{"path":"/workspace/schema.idl","kind":"source"}],"output_groups":{"generated":[{"path":"bazel-out/bin/app/schema.ts","uri":"file:///workspace/bazel-out/bin/app/schema.ts","digest":"abc123"}],"manifest":[]},"output_groups_complete":true}
+```
+
+Consumers should only replace their previous artifact set when
+`output_groups_complete` is true. Failed builds and BEP parsing failures leave
+the field unset, allowing consumers to retain their last-good outputs. Artifact
+digests, inline contents, symlink targets, and lengths are included when Bazel
+reports them.
+
 ## Output Runner
 
 iBazel is capable of producing and running commands from the output of Bazel

--- a/internal/e2e/notify_output_groups/BUILD
+++ b/internal/e2e/notify_output_groups/BUILD
@@ -1,0 +1,7 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "notify_output_groups_test",
+    srcs = ["notify_output_groups_test.go"],
+    deps = ["//internal/e2e"],
+)

--- a/internal/e2e/notify_output_groups/notify_output_groups_test.go
+++ b/internal/e2e/notify_output_groups/notify_output_groups_test.go
@@ -12,9 +12,9 @@ const mainFiles = `
 -- BUILD.bazel --
 load(":notify_app.bzl", "notify_app")
 
-cc_binary(
+sh_binary(
     name = "notification_server",
-    srcs = ["notification_server.cc"],
+    srcs = ["notification_server.sh"],
 )
 
 notify_app(
@@ -62,18 +62,12 @@ notify_app = rule(
     },
     executable = True,
 )
--- notification_server.cc --
-#include <iostream>
-#include <string>
-
-int main() {
-    std::cout << "ready" << std::endl;
-    for (std::string line; std::getline(std::cin, line);) {
-        std::cout << line << std::endl;
-    }
-    return 0;
-}
-
+-- notification_server.sh --
+#!/usr/bin/env bash
+printf 'ready\n'
+while IFS= read -r line; do
+    printf '%s\n' "$line"
+done
 -- source.txt --
 generated output
 `

--- a/internal/e2e/notify_output_groups/notify_output_groups_test.go
+++ b/internal/e2e/notify_output_groups/notify_output_groups_test.go
@@ -1,0 +1,122 @@
+package notify_output_groups
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/bazel-watcher/internal/e2e"
+)
+
+const mainFiles = `
+-- BUILD.bazel --
+load(":notify_app.bzl", "notify_app")
+
+cc_binary(
+    name = "notification_server",
+    srcs = ["notification_server.cc"],
+)
+
+notify_app(
+    name = "app",
+    binary = ":notification_server",
+    src = "source.txt",
+    tags = [
+        "ibazel_notify_changes",
+        "ibazel_notify_changes_v1",
+    ],
+)
+-- notify_app.bzl --
+def _notify_app_impl(ctx):
+    extension = ctx.executable.binary.extension
+    executable = ctx.actions.declare_file(
+        ctx.label.name + ("." + extension if extension else ""),
+    )
+    ctx.actions.symlink(
+        output = executable,
+        target_file = ctx.executable.binary,
+        is_executable = True,
+    )
+
+    generated = ctx.actions.declare_file(ctx.label.name + ".generated.txt")
+    ctx.actions.run_shell(
+        inputs = [ctx.file.src],
+        outputs = [generated],
+        arguments = [ctx.file.src.path, generated.path],
+        command = "cp $1 $2",
+    )
+
+    return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = ctx.attr.binary[DefaultInfo].default_runfiles,
+        ),
+        OutputGroupInfo(generated = depset([generated])),
+    ]
+
+notify_app = rule(
+    implementation = _notify_app_impl,
+    attrs = {
+        "binary": attr.label(executable = True, cfg = "target"),
+        "src": attr.label(allow_single_file = True),
+    },
+    executable = True,
+)
+-- notification_server.cc --
+#include <iostream>
+#include <string>
+
+int main() {
+    std::cout << "ready" << std::endl;
+    for (std::string line; std::getline(std::cin, line);) {
+        std::cout << line << std::endl;
+    }
+    return 0;
+}
+
+-- source.txt --
+generated output
+`
+
+func TestMain(m *testing.M) {
+	e2e.TestMain(m, e2e.Args{Main: mainFiles})
+}
+
+func TestStructuredNotificationIncludesBazelOutputGroup(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	ibazel.RunWithAdditionalArgs("//:app", []string{"--notify_output_groups=generated"})
+	defer ibazel.Kill()
+
+	ibazel.ExpectOutput("IBAZEL_EVENT ")
+
+	var event struct {
+		OutputGroups map[string][]struct {
+			Path string `json:"path"`
+			URI  string `json:"uri"`
+		} `json:"output_groups"`
+		OutputGroupsComplete bool `json:"output_groups_complete"`
+	}
+	for _, line := range strings.Split(ibazel.GetOutput(), "\n") {
+		if !strings.HasPrefix(line, "IBAZEL_EVENT ") {
+			continue
+		}
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "IBAZEL_EVENT ")), &event); err != nil {
+			t.Fatalf("decode structured notification: %v", err)
+		}
+		break
+	}
+
+	if !event.OutputGroupsComplete {
+		t.Fatal("output groups were not marked complete")
+	}
+	outputs := event.OutputGroups["generated"]
+	if len(outputs) != 1 {
+		t.Fatalf("generated outputs = %v, want one output", outputs)
+	}
+	if !strings.HasSuffix(outputs[0].Path, "/app.generated.txt") {
+		t.Errorf("generated output path = %q", outputs[0].Path)
+	}
+	if !strings.HasPrefix(outputs[0].URI, "file://") {
+		t.Errorf("generated output URI = %q, want file URI", outputs[0].URI)
+	}
+}

--- a/internal/ibazel/BUILD
+++ b/internal/ibazel/BUILD
@@ -35,6 +35,7 @@ go_library(
         "//internal/ibazel/output_runner",
         "//internal/ibazel/profiler",
         "//internal/ibazel/workspace",
+        "//third_party/bazel/master/src/main/protobuf/analysis",
         "//third_party/bazel/master/src/main/protobuf/blaze_query",
     ],
 )

--- a/internal/ibazel/bep/BUILD
+++ b/internal/ibazel/bep/BUILD
@@ -1,0 +1,30 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "bep",
+    srcs = ["outputs.go"],
+    importpath = "github.com/bazelbuild/bazel-watcher/internal/ibazel/bep",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "bep_test",
+    size = "small",
+    srcs = ["outputs_test.go"],
+    embed = [":bep"],
+    deps = ["@com_github_google_go_cmp//cmp"],
+)

--- a/internal/ibazel/bep/outputs.go
+++ b/internal/ibazel/bep/outputs.go
@@ -1,0 +1,200 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bep reads the subset of Bazel's JSON Build Event Protocol needed by
+// notification-mode commands.
+package bep
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+)
+
+// Output identifies one artifact in a Bazel output group. Contents uses the
+// base64 encoding from Bazel's JSON representation of the BEP.
+type Output struct {
+	Path              string `json:"path"`
+	URI               string `json:"uri,omitempty"`
+	Contents          string `json:"contents,omitempty"`
+	SymlinkTargetPath string `json:"symlink_target_path,omitempty"`
+	Digest            string `json:"digest,omitempty"`
+	Length            int64  `json:"length,omitempty"`
+}
+
+type event struct {
+	ID              eventID          `json:"id"`
+	NamedSetOfFiles *namedSetOfFiles `json:"namedSetOfFiles"`
+	Completed       *targetComplete  `json:"completed"`
+}
+
+type eventID struct {
+	NamedSet *namedSetID `json:"namedSet"`
+}
+
+type namedSetID struct {
+	ID string `json:"id"`
+}
+
+type namedSetOfFiles struct {
+	Files    []file       `json:"files"`
+	FileSets []namedSetID `json:"fileSets"`
+}
+
+type file struct {
+	Name              string   `json:"name"`
+	URI               string   `json:"uri"`
+	Contents          string   `json:"contents"`
+	SymlinkTargetPath string   `json:"symlinkTargetPath"`
+	PathPrefix        []string `json:"pathPrefix"`
+	Digest            string   `json:"digest"`
+	Length            int64    `json:"length,string"`
+}
+
+type targetComplete struct {
+	OutputGroups []outputGroup `json:"outputGroup"`
+}
+
+type outputGroup struct {
+	Name        string       `json:"name"`
+	FileSets    []namedSetID `json:"fileSets"`
+	Incomplete  bool         `json:"incomplete"`
+	InlineFiles []file       `json:"inlineFiles"`
+}
+
+// ReadOutputGroups extracts selected output groups from a JSON BEP stream.
+func ReadOutputGroups(reader io.Reader, selected []string) (map[string][]Output, error) {
+	wanted := make(map[string]struct{}, len(selected))
+	type groupFiles struct {
+		roots  []string
+		inline []file
+	}
+	groups := make(map[string]*groupFiles, len(selected))
+	seenGroups := make(map[string]struct{}, len(selected))
+	for _, name := range selected {
+		wanted[name] = struct{}{}
+		groups[name] = &groupFiles{}
+	}
+
+	namedSets := make(map[string]namedSetOfFiles)
+	decoder := json.NewDecoder(reader)
+	for {
+		var current event
+		if err := decoder.Decode(&current); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("decode BEP: %w", err)
+		}
+
+		if current.ID.NamedSet != nil && current.NamedSetOfFiles != nil {
+			namedSets[current.ID.NamedSet.ID] = *current.NamedSetOfFiles
+		}
+		if current.Completed == nil {
+			continue
+		}
+		for _, group := range current.Completed.OutputGroups {
+			if _, ok := wanted[group.Name]; !ok {
+				continue
+			}
+			if group.Incomplete {
+				return nil, fmt.Errorf("output group %q is incomplete", group.Name)
+			}
+			seenGroups[group.Name] = struct{}{}
+			for _, fileSet := range group.FileSets {
+				groups[group.Name].roots = append(groups[group.Name].roots, fileSet.ID)
+			}
+			groups[group.Name].inline = append(groups[group.Name].inline, group.InlineFiles...)
+		}
+	}
+
+	outputs := make(map[string][]Output, len(groups))
+	for name, group := range groups {
+		if _, ok := seenGroups[name]; !ok {
+			return nil, fmt.Errorf("output group %q was not reported", name)
+		}
+		files, err := expandNamedSets(namedSets, group.roots)
+		if err != nil {
+			return nil, fmt.Errorf("read output group %q: %w", name, err)
+		}
+		files = append(files, outputsFromFiles(group.inline)...)
+		outputs[name], err = deduplicate(files)
+		if err != nil {
+			return nil, fmt.Errorf("read output group %q: %w", name, err)
+		}
+	}
+	return outputs, nil
+}
+
+func expandNamedSets(namedSets map[string]namedSetOfFiles, roots []string) ([]Output, error) {
+	seenSets := make(map[string]struct{})
+	var outputs []Output
+	stack := append([]string(nil), roots...)
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		id := stack[last]
+		stack = stack[:last]
+		if _, ok := seenSets[id]; ok {
+			continue
+		}
+		seenSets[id] = struct{}{}
+
+		set, ok := namedSets[id]
+		if !ok {
+			return nil, fmt.Errorf("missing named set %q", id)
+		}
+		outputs = append(outputs, outputsFromFiles(set.Files)...)
+		for _, child := range set.FileSets {
+			stack = append(stack, child.ID)
+		}
+	}
+
+	return deduplicate(outputs)
+}
+
+func outputsFromFiles(files []file) []Output {
+	outputs := make([]Output, 0, len(files))
+	for _, item := range files {
+		outputs = append(outputs, Output{
+			Path:              path.Join(append(item.PathPrefix, item.Name)...),
+			URI:               item.URI,
+			Contents:          item.Contents,
+			SymlinkTargetPath: item.SymlinkTargetPath,
+			Digest:            item.Digest,
+			Length:            item.Length,
+		})
+	}
+	return outputs
+}
+
+func deduplicate(files []Output) ([]Output, error) {
+	seen := make(map[string]Output, len(files))
+	for _, output := range files {
+		if previous, ok := seen[output.Path]; ok && previous != output {
+			return nil, fmt.Errorf("artifact %q has conflicting metadata", output.Path)
+		}
+		seen[output.Path] = output
+	}
+
+	outputs := make([]Output, 0, len(seen))
+	for _, output := range seen {
+		outputs = append(outputs, output)
+	}
+	sort.Slice(outputs, func(i, j int) bool {
+		return outputs[i].Path < outputs[j].Path
+	})
+	return outputs, nil
+}

--- a/internal/ibazel/bep/outputs_test.go
+++ b/internal/ibazel/bep/outputs_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bep
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestReadOutputGroups(t *testing.T) {
+	stream := strings.NewReader(`
+{"id":{"namedSet":{"id":"child"}},"namedSetOfFiles":{"files":[{"name":"schema.ts","uri":"file:///execroot/bazel-out/bin/schema.ts","pathPrefix":["bazel-out","bin"],"digest":"schema-digest","length":"42"}]}}
+{"id":{"namedSet":{"id":"root"}},"namedSetOfFiles":{"files":[{"name":"routes.ts","uri":"file:///execroot/bazel-out/bin/routes.ts","pathPrefix":["bazel-out","bin"],"digest":"routes-digest"}],"fileSets":[{"id":"child"}]}}
+{"id":{"targetCompleted":{"label":"//app:dev"}},"completed":{"success":true,"outputGroup":[{"name":"generated","fileSets":[{"id":"root"}],"inlineFiles":[{"name":"metadata.json","pathPrefix":["bazel-out","bin"],"contents":"e30=","length":"2"},{"name":"link","pathPrefix":["bazel-out","bin"],"symlinkTargetPath":"schema.ts"}]},{"name":"manifest","fileSets":[]},{"name":"default","fileSets":[]}]}}
+`)
+
+	got, err := ReadOutputGroups(stream, []string{"generated", "manifest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string][]Output{
+		"generated": {
+			{Path: "bazel-out/bin/link", SymlinkTargetPath: "schema.ts"},
+			{Path: "bazel-out/bin/metadata.json", Contents: "e30=", Length: 2},
+			{Path: "bazel-out/bin/routes.ts", URI: "file:///execroot/bazel-out/bin/routes.ts", Digest: "routes-digest"},
+			{Path: "bazel-out/bin/schema.ts", URI: "file:///execroot/bazel-out/bin/schema.ts", Digest: "schema-digest", Length: 42},
+		},
+		"manifest": {},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("output groups diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestReadOutputGroupsRejectsMissingGroup(t *testing.T) {
+	stream := strings.NewReader(`{"id":{"targetCompleted":{"label":"//app:dev"}},"completed":{"success":true,"outputGroup":[{"name":"default","fileSets":[]}]}}`)
+
+	_, err := ReadOutputGroups(stream, []string{"generated"})
+	if err == nil || !strings.Contains(err.Error(), `output group "generated" was not reported`) {
+		t.Fatalf("ReadOutputGroups() error = %v, want missing group error", err)
+	}
+}
+
+func TestReadOutputGroupsRejectsIncompleteGroup(t *testing.T) {
+	stream := strings.NewReader(`{"id":{"targetCompleted":{"label":"//app:dev"}},"completed":{"success":true,"outputGroup":[{"name":"generated","incomplete":true}]}}`)
+
+	_, err := ReadOutputGroups(stream, []string{"generated"})
+	if err == nil || !strings.Contains(err.Error(), `output group "generated" is incomplete`) {
+		t.Fatalf("ReadOutputGroups() error = %v, want incomplete group error", err)
+	}
+}
+
+func TestReadOutputGroupsRejectsMissingNamedSet(t *testing.T) {
+	stream := strings.NewReader(`{"id":{"targetCompleted":{"label":"//app:dev"}},"completed":{"success":true,"outputGroup":[{"name":"generated","fileSets":[{"id":"missing"}]}]}}`)
+
+	_, err := ReadOutputGroups(stream, []string{"generated"})
+	if err == nil || !strings.Contains(err.Error(), `missing named set "missing"`) {
+		t.Fatalf("ReadOutputGroups() error = %v, want missing named set error", err)
+	}
+}
+
+func TestReadOutputGroupsRejectsConflictingMetadata(t *testing.T) {
+	stream := strings.NewReader(`
+{"id":{"namedSet":{"id":"outputs"}},"namedSetOfFiles":{"files":[{"name":"result.txt","pathPrefix":["bazel-out","bin"],"digest":"one"},{"name":"result.txt","pathPrefix":["bazel-out","bin"],"digest":"two"}]}}
+{"id":{"targetCompleted":{"label":"//app:dev"}},"completed":{"success":true,"outputGroup":[{"name":"generated","fileSets":[{"id":"outputs"}]}]}}
+`)
+
+	_, err := ReadOutputGroups(stream, []string{"generated"})
+	if err == nil || !strings.Contains(err.Error(), `artifact "bazel-out/bin/result.txt" has conflicting metadata`) {
+		t.Fatalf("ReadOutputGroups() error = %v, want conflicting metadata error", err)
+	}
+}

--- a/internal/ibazel/command/BUILD
+++ b/internal/ibazel/command/BUILD
@@ -25,6 +25,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/bazel",
+        "//internal/ibazel/bep",
         "//internal/ibazel/log",
         "//internal/ibazel/process_group",
     ],
@@ -43,7 +44,9 @@ go_test(
     deps = [
         "//internal/bazel",
         "//internal/bazel/testing",
+        "//internal/ibazel/bep",
         "//internal/ibazel/log",
         "//internal/ibazel/process_group",
+        "@com_github_google_go_cmp//cmp",
     ],
 )

--- a/internal/ibazel/command/command.go
+++ b/internal/ibazel/command/command.go
@@ -46,7 +46,7 @@ type Command interface {
 	Start() (*bytes.Buffer, error)
 	Terminate()
 	Kill()
-	NotifyOfChanges(changes []Change) *bytes.Buffer
+	NotifyOfChanges(changes []Change, impact ChangeImpact) *bytes.Buffer
 	IsSubprocessRunning() bool
 }
 
@@ -54,6 +54,12 @@ type Command interface {
 type Change struct {
 	Path string `json:"path"`
 	Kind string `json:"kind"`
+}
+
+// ChangeImpact describes which notification-mode child targets own a change.
+type ChangeImpact struct {
+	Targets  []string
+	Complete bool
 }
 
 // start will be called by most implementations since this logic is extremely

--- a/internal/ibazel/command/default_command.go
+++ b/internal/ibazel/command/default_command.go
@@ -84,7 +84,7 @@ func (c *defaultCommand) Start() (*bytes.Buffer, error) {
 	return outputBuffer, nil
 }
 
-func (c *defaultCommand) NotifyOfChanges(_ []Change) *bytes.Buffer {
+func (c *defaultCommand) NotifyOfChanges(_ []Change, _ ChangeImpact) *bytes.Buffer {
 	c.Terminate()
 	c.Start()
 	return nil

--- a/internal/ibazel/command/default_command_test.go
+++ b/internal/ibazel/command/default_command_test.go
@@ -63,7 +63,7 @@ func TestDefaultCommand(t *testing.T) {
 	}
 
 	// This is synonymous with killing the job so use it to kill the job and test everything.
-	c.NotifyOfChanges(nil)
+	c.NotifyOfChanges(nil, ChangeImpact{})
 	assertKilled(t, toKill.RootProcess())
 }
 

--- a/internal/ibazel/command/notify_command.go
+++ b/internal/ibazel/command/notify_command.go
@@ -19,39 +19,45 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 	"sync"
 
+	"github.com/bazelbuild/bazel-watcher/internal/ibazel/bep"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/process_group"
 )
 
 type notifyCommand struct {
-	target      string
-	startupArgs []string
-	bazelArgs   []string
-	args        []string
-	pg          process_group.ProcessGroup
-	stdin       io.WriteCloser
-	structured  bool
-	termSync    sync.Once
+	target       string
+	startupArgs  []string
+	bazelArgs    []string
+	args         []string
+	pg           process_group.ProcessGroup
+	stdin        io.WriteCloser
+	structured   bool
+	outputGroups []string
+	termSync     sync.Once
 }
 
 type buildEvent struct {
-	Version int      `json:"version"`
-	Type    string   `json:"type"`
-	Success bool     `json:"success"`
-	Changes []Change `json:"changes"`
+	Version              int                     `json:"version"`
+	Type                 string                  `json:"type"`
+	Success              bool                    `json:"success"`
+	Changes              []Change                `json:"changes"`
+	OutputGroups         map[string][]bep.Output `json:"output_groups,omitempty"`
+	OutputGroupsComplete bool                    `json:"output_groups_complete,omitempty"`
 }
 
 // NotifyCommand is an alternate mode for starting a command. In this mode the
 // command will be notified on stdin that the source files have changed.
-func NotifyCommand(startupArgs []string, bazelArgs []string, target string, args []string, structured bool) Command {
+func NotifyCommand(startupArgs []string, bazelArgs []string, target string, args []string, structured bool, outputGroups []string) Command {
 	return &notifyCommand{
-		startupArgs: startupArgs,
-		target:      target,
-		bazelArgs:   bazelArgs,
-		args:        args,
-		structured:  structured,
+		startupArgs:  startupArgs,
+		target:       target,
+		bazelArgs:    bazelArgs,
+		args:         args,
+		structured:   structured,
+		outputGroups: outputGroups,
 	}
 }
 
@@ -75,7 +81,7 @@ func (c *notifyCommand) Kill() {
 func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
-	b.SetArguments(c.bazelArgs)
+	b.SetArguments(c.argumentsWithOutputGroups())
 
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
@@ -104,7 +110,13 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 func (c *notifyCommand) NotifyOfChanges(changes []Change) *bytes.Buffer {
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
-	b.SetArguments(c.bazelArgs)
+	bepPath, cleanup := c.buildEventFile()
+	defer cleanup()
+	bazelArgs := c.argumentsWithOutputGroups()
+	if bepPath != "" {
+		bazelArgs = append(bazelArgs, "--build_event_json_file="+bepPath)
+	}
+	b.SetArguments(bazelArgs)
 
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
@@ -121,14 +133,15 @@ func (c *notifyCommand) NotifyOfChanges(changes []Change) *bytes.Buffer {
 		if err != nil {
 			log.Errorf("Error writing failure to stdin: %s", err)
 		}
-		c.writeBuildEvent(false, changes)
+		c.writeBuildEvent(false, changes, nil, false)
 	} else {
 		log.Log("IBAZEL BUILD SUCCESS")
 		_, err := c.stdin.Write([]byte("IBAZEL_BUILD_COMPLETED SUCCESS\n"))
 		if err != nil {
 			log.Errorf("Error writing success to stdin: %v", err)
 		}
-		c.writeBuildEvent(true, changes)
+		outputGroups, complete := c.readOutputGroups(bepPath)
+		c.writeBuildEvent(true, changes, outputGroups, complete)
 		if !c.IsSubprocessRunning() {
 			log.Log("Restarting process...")
 			c.Terminate()
@@ -138,15 +151,17 @@ func (c *notifyCommand) NotifyOfChanges(changes []Change) *bytes.Buffer {
 	return outputBuffer
 }
 
-func (c *notifyCommand) writeBuildEvent(success bool, changes []Change) {
+func (c *notifyCommand) writeBuildEvent(success bool, changes []Change, outputGroups map[string][]bep.Output, outputGroupsComplete bool) {
 	if !c.structured {
 		return
 	}
 	event, err := json.Marshal(buildEvent{
-		Version: 1,
-		Type:    "build_completed",
-		Success: success,
-		Changes: changes,
+		Version:              1,
+		Type:                 "build_completed",
+		Success:              success,
+		Changes:              changes,
+		OutputGroups:         outputGroups,
+		OutputGroupsComplete: outputGroupsComplete,
 	})
 	if err != nil {
 		log.Errorf("Error encoding build event: %v", err)
@@ -155,6 +170,53 @@ func (c *notifyCommand) writeBuildEvent(success bool, changes []Change) {
 	if _, err := c.stdin.Write(append(append([]byte("IBAZEL_EVENT "), event...), '\n')); err != nil {
 		log.Errorf("Error writing build event to stdin: %v", err)
 	}
+}
+
+func (c *notifyCommand) argumentsWithOutputGroups() []string {
+	args := append([]string(nil), c.bazelArgs...)
+	if len(c.outputGroups) == 0 {
+		return args
+	}
+	groups := make([]string, 0, len(c.outputGroups))
+	for _, group := range c.outputGroups {
+		groups = append(groups, "+"+group)
+	}
+	return append(args, "--output_groups="+strings.Join(groups, ","))
+}
+
+func (c *notifyCommand) buildEventFile() (string, func()) {
+	if !c.structured || len(c.outputGroups) == 0 {
+		return "", func() {}
+	}
+	file, err := os.CreateTemp("", "ibazel-bep-*.json")
+	if err != nil {
+		log.Errorf("Error creating build event file: %v", err)
+		return "", func() {}
+	}
+	if err := file.Close(); err != nil {
+		log.Errorf("Error closing build event file: %v", err)
+		_ = os.Remove(file.Name())
+		return "", func() {}
+	}
+	return file.Name(), func() { _ = os.Remove(file.Name()) }
+}
+
+func (c *notifyCommand) readOutputGroups(path string) (map[string][]bep.Output, bool) {
+	if path == "" {
+		return nil, false
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		log.Errorf("Error opening build events: %v", err)
+		return nil, false
+	}
+	defer file.Close()
+	groups, err := bep.ReadOutputGroups(file, c.outputGroups)
+	if err != nil {
+		log.Errorf("Error reading build event output groups: %v", err)
+		return nil, false
+	}
+	return groups, true
 }
 
 func (c *notifyCommand) IsSubprocessRunning() bool {

--- a/internal/ibazel/command/notify_command.go
+++ b/internal/ibazel/command/notify_command.go
@@ -40,12 +40,14 @@ type notifyCommand struct {
 }
 
 type buildEvent struct {
-	Version              int                     `json:"version"`
-	Type                 string                  `json:"type"`
-	Success              bool                    `json:"success"`
-	Changes              []Change                `json:"changes"`
-	OutputGroups         map[string][]bep.Output `json:"output_groups,omitempty"`
-	OutputGroupsComplete bool                    `json:"output_groups_complete,omitempty"`
+	Version                 int                     `json:"version"`
+	Type                    string                  `json:"type"`
+	Success                 bool                    `json:"success"`
+	Changes                 []Change                `json:"changes"`
+	AffectedTargets         []string                `json:"affected_targets,omitempty"`
+	AffectedTargetsComplete bool                    `json:"affected_targets_complete,omitempty"`
+	OutputGroups            map[string][]bep.Output `json:"output_groups,omitempty"`
+	OutputGroupsComplete    bool                    `json:"output_groups_complete,omitempty"`
 }
 
 // NotifyCommand is an alternate mode for starting a command. In this mode the
@@ -107,7 +109,7 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 	return outputBuffer, nil
 }
 
-func (c *notifyCommand) NotifyOfChanges(changes []Change) *bytes.Buffer {
+func (c *notifyCommand) NotifyOfChanges(changes []Change, impact ChangeImpact) *bytes.Buffer {
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
 	bepPath, cleanup := c.buildEventFile()
@@ -133,7 +135,7 @@ func (c *notifyCommand) NotifyOfChanges(changes []Change) *bytes.Buffer {
 		if err != nil {
 			log.Errorf("Error writing failure to stdin: %s", err)
 		}
-		c.writeBuildEvent(false, changes, nil, false)
+		c.writeBuildEvent(false, changes, impact, nil, false)
 	} else {
 		log.Log("IBAZEL BUILD SUCCESS")
 		_, err := c.stdin.Write([]byte("IBAZEL_BUILD_COMPLETED SUCCESS\n"))
@@ -141,7 +143,7 @@ func (c *notifyCommand) NotifyOfChanges(changes []Change) *bytes.Buffer {
 			log.Errorf("Error writing success to stdin: %v", err)
 		}
 		outputGroups, complete := c.readOutputGroups(bepPath)
-		c.writeBuildEvent(true, changes, outputGroups, complete)
+		c.writeBuildEvent(true, changes, impact, outputGroups, complete)
 		if !c.IsSubprocessRunning() {
 			log.Log("Restarting process...")
 			c.Terminate()
@@ -151,17 +153,19 @@ func (c *notifyCommand) NotifyOfChanges(changes []Change) *bytes.Buffer {
 	return outputBuffer
 }
 
-func (c *notifyCommand) writeBuildEvent(success bool, changes []Change, outputGroups map[string][]bep.Output, outputGroupsComplete bool) {
+func (c *notifyCommand) writeBuildEvent(success bool, changes []Change, impact ChangeImpact, outputGroups map[string][]bep.Output, outputGroupsComplete bool) {
 	if !c.structured {
 		return
 	}
 	event, err := json.Marshal(buildEvent{
-		Version:              1,
-		Type:                 "build_completed",
-		Success:              success,
-		Changes:              changes,
-		OutputGroups:         outputGroups,
-		OutputGroupsComplete: outputGroupsComplete,
+		Version:                 1,
+		Type:                    "build_completed",
+		Success:                 success,
+		Changes:                 changes,
+		AffectedTargets:         impact.Targets,
+		AffectedTargetsComplete: impact.Complete,
+		OutputGroups:            outputGroups,
+		OutputGroupsComplete:    outputGroupsComplete,
 	})
 	if err != nil {
 		log.Errorf("Error encoding build event: %v", err)

--- a/internal/ibazel/command/notify_command_test.go
+++ b/internal/ibazel/command/notify_command_test.go
@@ -17,16 +17,66 @@ package command
 import (
 	"bytes"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/bazelbuild/bazel-watcher/internal/bazel"
 	mock_bazel "github.com/bazelbuild/bazel-watcher/internal/bazel/testing"
+	"github.com/bazelbuild/bazel-watcher/internal/ibazel/bep"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/process_group"
+	"github.com/google/go-cmp/cmp"
 )
 
 type bufferWriteCloser struct {
 	bytes.Buffer
+}
+
+func TestNotifyCommandStructuredBuildEventWithOutputGroups(t *testing.T) {
+	stdin := &bufferWriteCloser{}
+	c := &notifyCommand{stdin: stdin, structured: true}
+	groups := map[string][]bep.Output{
+		"generated": {{Path: "bazel-out/bin/schema.ts", URI: "file:///execroot/bazel-out/bin/schema.ts", Digest: "abc123"}},
+	}
+
+	c.writeBuildEvent(true, nil, groups, true)
+
+	want := "IBAZEL_EVENT {\"version\":1,\"type\":\"build_completed\",\"success\":true,\"changes\":null,\"output_groups\":{\"generated\":[{\"path\":\"bazel-out/bin/schema.ts\",\"uri\":\"file:///execroot/bazel-out/bin/schema.ts\",\"digest\":\"abc123\"}]},\"output_groups_complete\":true}\n"
+	if got := stdin.String(); got != want {
+		t.Errorf("structured build event = %q, want %q", got, want)
+	}
+}
+
+func TestNotifyCommandOutputGroupArguments(t *testing.T) {
+	c := &notifyCommand{
+		bazelArgs:    []string{"--config=dev"},
+		outputGroups: []string{"generated", "manifest"},
+	}
+
+	want := []string{"--config=dev", "--output_groups=+generated,+manifest"}
+	if diff := cmp.Diff(want, c.argumentsWithOutputGroups()); diff != "" {
+		t.Errorf("argumentsWithOutputGroups() diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestNotifyCommandReadsOutputGroups(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bep.json")
+	contents := `{"id":{"namedSet":{"id":"outputs"}},"namedSetOfFiles":{"files":[{"name":"schema.ts","pathPrefix":["bazel-out","bin"]}]}}
+{"id":{"targetCompleted":{"label":"//app:dev"}},"completed":{"success":true,"outputGroup":[{"name":"generated","fileSets":[{"id":"outputs"}]}]}}`
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatal(err)
+	}
+	c := &notifyCommand{outputGroups: []string{"generated"}}
+
+	got, complete := c.readOutputGroups(path)
+	want := map[string][]bep.Output{"generated": {{Path: "bazel-out/bin/schema.ts"}}}
+	if !complete {
+		t.Fatal("readOutputGroups() marked valid BEP incomplete")
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("readOutputGroups() diff (-want +got):\n%s", diff)
+	}
 }
 
 func (b *bufferWriteCloser) Close() error { return nil }
@@ -39,7 +89,7 @@ func TestNotifyCommandStructuredBuildEvent(t *testing.T) {
 		{Path: "/workspace/frontend/BUILD", Kind: "graph"},
 	}
 
-	c.writeBuildEvent(true, changes)
+	c.writeBuildEvent(true, changes, nil, false)
 
 	want := "IBAZEL_EVENT {\"version\":1,\"type\":\"build_completed\",\"success\":true,\"changes\":[{\"path\":\"/workspace/frontend/app.tsx\",\"kind\":\"source\"},{\"path\":\"/workspace/frontend/BUILD\",\"kind\":\"graph\"}]}\n"
 	if got := stdin.String(); got != want {
@@ -51,7 +101,7 @@ func TestNotifyCommandLegacyProtocolDoesNotWriteBuildEvent(t *testing.T) {
 	stdin := &bufferWriteCloser{}
 	c := &notifyCommand{stdin: stdin}
 
-	c.writeBuildEvent(true, []Change{{Path: "/workspace/app.ts", Kind: "source"}})
+	c.writeBuildEvent(true, []Change{{Path: "/workspace/app.ts", Kind: "source"}}, nil, false)
 
 	if got := stdin.String(); got != "" {
 		t.Errorf("legacy protocol wrote structured event %q", got)

--- a/internal/ibazel/command/notify_command_test.go
+++ b/internal/ibazel/command/notify_command_test.go
@@ -40,7 +40,7 @@ func TestNotifyCommandStructuredBuildEventWithOutputGroups(t *testing.T) {
 		"generated": {{Path: "bazel-out/bin/schema.ts", URI: "file:///execroot/bazel-out/bin/schema.ts", Digest: "abc123"}},
 	}
 
-	c.writeBuildEvent(true, nil, groups, true)
+	c.writeBuildEvent(true, nil, ChangeImpact{}, groups, true)
 
 	want := "IBAZEL_EVENT {\"version\":1,\"type\":\"build_completed\",\"success\":true,\"changes\":null,\"output_groups\":{\"generated\":[{\"path\":\"bazel-out/bin/schema.ts\",\"uri\":\"file:///execroot/bazel-out/bin/schema.ts\",\"digest\":\"abc123\"}]},\"output_groups_complete\":true}\n"
 	if got := stdin.String(); got != want {
@@ -89,9 +89,12 @@ func TestNotifyCommandStructuredBuildEvent(t *testing.T) {
 		{Path: "/workspace/frontend/BUILD", Kind: "graph"},
 	}
 
-	c.writeBuildEvent(true, changes, nil, false)
+	c.writeBuildEvent(true, changes, ChangeImpact{
+		Targets:  []string{"//frontend:dev"},
+		Complete: true,
+	}, nil, false)
 
-	want := "IBAZEL_EVENT {\"version\":1,\"type\":\"build_completed\",\"success\":true,\"changes\":[{\"path\":\"/workspace/frontend/app.tsx\",\"kind\":\"source\"},{\"path\":\"/workspace/frontend/BUILD\",\"kind\":\"graph\"}]}\n"
+	want := "IBAZEL_EVENT {\"version\":1,\"type\":\"build_completed\",\"success\":true,\"changes\":[{\"path\":\"/workspace/frontend/app.tsx\",\"kind\":\"source\"},{\"path\":\"/workspace/frontend/BUILD\",\"kind\":\"graph\"}],\"affected_targets\":[\"//frontend:dev\"],\"affected_targets_complete\":true}\n"
 	if got := stdin.String(); got != want {
 		t.Errorf("structured build event = %q, want %q", got, want)
 	}
@@ -101,7 +104,7 @@ func TestNotifyCommandLegacyProtocolDoesNotWriteBuildEvent(t *testing.T) {
 	stdin := &bufferWriteCloser{}
 	c := &notifyCommand{stdin: stdin}
 
-	c.writeBuildEvent(true, []Change{{Path: "/workspace/app.ts", Kind: "source"}}, nil, false)
+	c.writeBuildEvent(true, []Change{{Path: "/workspace/app.ts", Kind: "source"}}, ChangeImpact{}, nil, false)
 
 	if got := stdin.String(); got != "" {
 		t.Errorf("legacy protocol wrote structured event %q", got)
@@ -136,11 +139,11 @@ func TestNotifyCommand(t *testing.T) {
 	bazelNew = func() bazel.Bazel { return b }
 	defer func() { bazelNew = oldBazelNew }()
 
-	c.NotifyOfChanges(nil)
+	c.NotifyOfChanges(nil, ChangeImpact{})
 	b.BuildError(errors.New("Demo error"))
-	c.NotifyOfChanges(nil)
+	c.NotifyOfChanges(nil, ChangeImpact{})
 	b.BuildError(nil)
-	c.NotifyOfChanges(nil)
+	c.NotifyOfChanges(nil, ChangeImpact{})
 
 	b.AssertActions(t, [][]string{
 		{"SetStartupArgs"},
@@ -204,14 +207,14 @@ func TestNotifyCommand_Restart(t *testing.T) {
 		t.Errorf("new subprocess shouldn't have been started yet. State: %v", pg.RootProcess().ProcessState)
 	}
 
-	c.NotifyOfChanges(nil)
+	c.NotifyOfChanges(nil, ChangeImpact{})
 	if c.IsSubprocessRunning() {
 		t.Errorf("process should not start with build errors. State: %v", pg.RootProcess().ProcessState)
 	}
 
 	// Since the process isn't currently running, this should start it.
 	b.BuildError(nil)
-	c.NotifyOfChanges(nil)
+	c.NotifyOfChanges(nil, ChangeImpact{})
 	if !c.IsSubprocessRunning() {
 		t.Errorf("subprocess should have started. State: %v", pg.RootProcess().ProcessState)
 	}
@@ -224,14 +227,14 @@ func TestNotifyCommand_Restart(t *testing.T) {
 	}
 
 	b.BuildError(errors.New("Demo error"))
-	c.NotifyOfChanges(nil)
+	c.NotifyOfChanges(nil, ChangeImpact{})
 	if c.IsSubprocessRunning() {
 		t.Errorf("subprocess should not restart with build errors. State: %v", pg.RootProcess().ProcessState)
 	}
 
 	// Since the process isn't currently running, this should re-start it.
 	b.BuildError(nil)
-	c.NotifyOfChanges(nil)
+	c.NotifyOfChanges(nil, ChangeImpact{})
 	if !c.IsSubprocessRunning() {
 		t.Errorf("subprocess should have been restarted. State: %v", pg.RootProcess().ProcessState)
 	}
@@ -241,7 +244,7 @@ func TestNotifyCommand_Restart(t *testing.T) {
 		t.Error("PIDs of restarted process should be different that original process")
 	}
 
-	c.NotifyOfChanges(nil)
+	c.NotifyOfChanges(nil, ChangeImpact{})
 	if pid2 != c.pg.RootProcess().Process.Pid {
 		t.Error("non-dead process was restarted")
 	}

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -36,6 +37,7 @@ import (
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/output_runner"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/profiler"
 	"github.com/bazelbuild/bazel-watcher/internal/ibazel/workspace"
+	analysispb "github.com/bazelbuild/bazel-watcher/third_party/bazel/master/src/main/protobuf/analysis"
 	"github.com/bazelbuild/bazel-watcher/third_party/bazel/master/src/main/protobuf/blaze_query"
 )
 
@@ -70,7 +72,6 @@ const (
 	notificationExecution
 )
 
-const sourceQuery = "kind('source file', deps(set(%s)))"
 const targetQuery = "deps(set(%s))"
 const buildQuery = "buildfiles(set(%s))"
 
@@ -95,6 +96,9 @@ type IBazel struct {
 	lifecycleListeners []Lifecycle
 	pendingChanges     []command.Change
 	executionMode      executionMode
+	changeOwners       map[string][]string
+	directTargets      []string
+	ownershipReady     bool
 
 	state State
 }
@@ -330,17 +334,17 @@ func (i *IBazel) iteration(commandName string, commandToRun runnableCommand, tar
 		// Query for which files to watch.
 		log.Logf("Querying for files to watch...")
 
-		toWatchBuildFiles, err := i.queryForBuildFiles(joinedTargets)
+		toWatchBuildFiles, targetGraph, err := i.queryForBuildFiles(joinedTargets)
 		if err != nil {
 			log.Errorf("Error querying for build files: %v", err)
 		} else {
 			i.watchFiles(toWatchBuildFiles, i.buildFileWatcher)
-		}
-
-		toWatchSourceFiles, err := i.queryForSourceFiles(joinedTargets)
-		if err != nil {
-			log.Errorf("Error querying for source files: %v", err)
-		} else {
+			toWatchSourceFiles, sourcePathsByLabel, sourceErr := i.sourceFilesFromGraph(targetGraph)
+			if sourceErr != nil {
+				log.Errorf("Error resolving source files: %v", sourceErr)
+			} else {
+				i.changeOwners, i.ownershipReady = i.sourceOwnersFromGraph(targetGraph, sourcePathsByLabel)
+			}
 			i.watchFiles(toWatchSourceFiles, i.sourceFileWatcher)
 		}
 
@@ -465,6 +469,7 @@ func (i *IBazel) setupRun(target string) command.Command {
 			}
 		}
 	}
+	i.directTargets = append([]string(nil), rule.RuleInput...)
 
 	if commandNotify {
 		i.executionMode = notificationStartupExecution
@@ -516,9 +521,35 @@ func (i *IBazel) run(targets ...string) (*bytes.Buffer, error) {
 		return outputBuffer, err
 	default:
 		log.Logf("Notifying of changes")
-		outputBuffer := i.cmd.NotifyOfChanges(i.pendingChanges)
+		outputBuffer := i.cmd.NotifyOfChanges(i.pendingChanges, i.changeImpact())
 		return outputBuffer, nil
 	}
+}
+
+func (i *IBazel) changeImpact() command.ChangeImpact {
+	if !i.ownershipReady || len(i.pendingChanges) == 0 {
+		return command.ChangeImpact{}
+	}
+
+	targets := make(map[string]struct{})
+	complete := true
+	for _, change := range i.pendingChanges {
+		owners, ok := i.changeOwners[change.Path]
+		if !ok {
+			complete = false
+			continue
+		}
+		for _, target := range owners {
+			targets[target] = struct{}{}
+		}
+	}
+
+	result := make([]string, 0, len(targets))
+	for target := range targets {
+		result = append(result, target)
+	}
+	sort.Strings(result)
+	return command.ChangeImpact{Targets: result, Complete: complete}
 }
 
 func (i *IBazel) queryRule(rule string) (*blaze_query.Rule, error) {
@@ -567,41 +598,18 @@ func (i *IBazel) dumpRootRepoMapping() (map[string]string, *bytes.Buffer, error)
 	return res, stderr, nil
 }
 
-func (i *IBazel) queryForSourceFiles(targets string) ([]string, error) {
-	b := i.newBazel()
-
-	res, err := b.CQuery(i.cQueryArgs(fmt.Sprintf(sourceQuery, targets))...)
-	if err != nil {
-		log.Errorf("Bazel cquery failed: %v", err)
-		return nil, err
-	}
-
-	labels := make([]string, 0, len(res.Results))
-	for _, target := range res.Results {
-		switch *target.Target.Type {
-		case blaze_query.Target_SOURCE_FILE:
-			label := target.Target.SourceFile.GetName()
-			labels = append(labels, label)
-		default:
-			log.Errorf("%v\n", target)
-		}
-	}
-
-	return i.labelsToWatch(labels)
-}
-
-func (i *IBazel) queryForBuildFiles(targets string) ([]string, error) {
+func (i *IBazel) queryForBuildFiles(targets string) ([]string, *analysispb.CqueryResult, error) {
 	b := i.newBazel()
 
 	targetRes, err := b.CQuery(i.cQueryArgs(fmt.Sprintf(targetQuery, targets))...)
 	if err != nil {
 		log.Errorf("Bazel target query failed: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	localRepositories, err := i.realLocalRepositoryPaths()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	quotedBuildTargets := make([]string, 0, len(targetRes.Results))
 	for _, configuredTarget := range targetRes.Results {
@@ -625,7 +633,7 @@ func (i *IBazel) queryForBuildFiles(targets string) ([]string, error) {
 
 	f, err := os.CreateTemp("", "query")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create query file: %w", err)
+		return nil, nil, fmt.Errorf("failed to create query file: %w", err)
 	}
 	defer func() {
 		f.Close()
@@ -633,13 +641,13 @@ func (i *IBazel) queryForBuildFiles(targets string) ([]string, error) {
 	}()
 	_, err = f.WriteString(fmt.Sprintf(buildQuery, strings.Join(quotedBuildTargets, " ")))
 	if err != nil {
-		return nil, fmt.Errorf("failed to write query file: %w", err)
+		return nil, nil, fmt.Errorf("failed to write query file: %w", err)
 	}
 
 	res, err := b.Query(i.queryArgs(fmt.Sprintf("--query_file=%s", f.Name()))...)
 	if err != nil {
 		log.Errorf("Bazel query failed: %v", err)
-		return nil, err
+		return nil, nil, err
 	}
 
 	labels := make([]string, 0, len(res.GetTarget()))
@@ -653,7 +661,136 @@ func (i *IBazel) queryForBuildFiles(targets string) ([]string, error) {
 		}
 	}
 
-	return i.labelsToWatch(labels)
+	paths, err := i.labelsToWatch(labels)
+	return paths, targetRes, err
+}
+
+func (i *IBazel) sourceFilesFromGraph(graph *analysispb.CqueryResult) ([]string, map[string]string, error) {
+	labels := make([]string, 0, len(graph.Results))
+	for _, configuredTarget := range graph.Results {
+		if configuredTarget.Target.GetType() != blaze_query.Target_SOURCE_FILE {
+			continue
+		}
+		labels = append(labels, configuredTarget.Target.SourceFile.GetName())
+	}
+	pathsByLabel, err := i.labelsToWatchMap(labels)
+	if err != nil {
+		return nil, nil, err
+	}
+	paths := make([]string, 0, len(pathsByLabel))
+	for _, label := range labels {
+		if path, ok := pathsByLabel[label]; ok {
+			paths = append(paths, path)
+		}
+	}
+	return paths, pathsByLabel, nil
+}
+
+func (i *IBazel) sourceOwnersFromGraph(graph *analysispb.CqueryResult, pathsByLabel map[string]string) (map[string][]string, bool) {
+	if len(i.directTargets) == 0 {
+		return nil, false
+	}
+
+	dependencies := make(map[string][]string)
+	sources := make(map[string]struct{})
+	locations := make(map[string]string)
+	for _, configuredTarget := range graph.Results {
+		target := configuredTarget.Target
+		switch target.GetType() {
+		case blaze_query.Target_RULE:
+			name := target.Rule.GetName()
+			dependencies[name] = append(dependencies[name], target.Rule.RuleInput...)
+			locations[name] = ruleLocationPath(target.Rule.GetLocation())
+		case blaze_query.Target_GENERATED_FILE:
+			dependencies[target.GeneratedFile.GetName()] = []string{target.GeneratedFile.GetGeneratingRule()}
+		case blaze_query.Target_SOURCE_FILE:
+			sources[target.SourceFile.GetName()] = struct{}{}
+		}
+	}
+
+	ownersByLabel := make(map[string]map[string]struct{})
+	ownersByLocation := make(map[string]map[string]struct{})
+	for _, root := range i.directTargets {
+		if _, ok := locations[root]; !ok {
+			continue
+		}
+		seen := make(map[string]struct{})
+		stack := []string{root}
+		for len(stack) > 0 {
+			label := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if _, ok := seen[label]; ok {
+				continue
+			}
+			seen[label] = struct{}{}
+			if location := locations[label]; location != "" {
+				if ownersByLocation[location] == nil {
+					ownersByLocation[location] = make(map[string]struct{})
+				}
+				ownersByLocation[location][root] = struct{}{}
+			}
+			if _, ok := sources[label]; ok {
+				if ownersByLabel[label] == nil {
+					ownersByLabel[label] = make(map[string]struct{})
+				}
+				ownersByLabel[label][root] = struct{}{}
+			}
+			stack = append(stack, dependencies[label]...)
+		}
+	}
+
+	ownersByPath := make(map[string]map[string]struct{}, len(pathsByLabel))
+	for label, path := range pathsByLabel {
+		resolved, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			continue
+		}
+		if ownersByPath[resolved] == nil {
+			ownersByPath[resolved] = make(map[string]struct{})
+		}
+		for owner := range ownersByLabel[label] {
+			ownersByPath[resolved][owner] = struct{}{}
+		}
+	}
+	workspacePath, err := i.workspaceFinder.FindWorkspace()
+	if err != nil {
+		log.Errorf("Error finding workspace for graph ownership: %v", err)
+		return nil, false
+	}
+	for location, owners := range ownersByLocation {
+		if !filepath.IsAbs(location) {
+			location = filepath.Join(workspacePath, location)
+		}
+		resolved, err := filepath.EvalSymlinks(location)
+		if err != nil {
+			continue
+		}
+		if ownersByPath[resolved] == nil {
+			ownersByPath[resolved] = make(map[string]struct{})
+		}
+		for owner := range owners {
+			ownersByPath[resolved][owner] = struct{}{}
+		}
+	}
+	result := make(map[string][]string, len(ownersByPath))
+	for path, owners := range ownersByPath {
+		for owner := range owners {
+			result[path] = append(result[path], owner)
+		}
+		sort.Strings(result[path])
+	}
+	return result, true
+}
+
+func ruleLocationPath(location string) string {
+	for range 2 {
+		index := strings.LastIndex(location, ":")
+		if index < 0 {
+			return ""
+		}
+		location = location[:index]
+	}
+	return location
 }
 
 func (i *IBazel) watchFiles(toWatch []string, watcher common.Watcher) {
@@ -690,6 +827,21 @@ func (i *IBazel) watchFiles(toWatch []string, watcher common.Watcher) {
 }
 
 func (i *IBazel) labelsToWatch(labels []string) ([]string, error) {
+	pathsByLabel, err := i.labelsToWatchMap(labels)
+	if err != nil {
+		return nil, err
+	}
+
+	toWatch := make([]string, 0, len(pathsByLabel))
+	for _, label := range labels {
+		if path, ok := pathsByLabel[label]; ok {
+			toWatch = append(toWatch, path)
+		}
+	}
+	return toWatch, nil
+}
+
+func (i *IBazel) labelsToWatchMap(labels []string) (map[string]string, error) {
 	localRepositories, err := i.realLocalRepositoryPaths()
 	if err != nil {
 		return nil, err
@@ -701,13 +853,14 @@ func (i *IBazel) labelsToWatch(labels []string) ([]string, error) {
 		return nil, err
 	}
 
-	toWatch := make([]string, 0, len(labels))
+	toWatch := make(map[string]string, len(labels))
 	for _, label := range labels {
+		original := label
 		if strings.HasPrefix(label, "@") {
 			repo, target := parseTarget(label)
 			if realPath, ok := localRepositories[repo]; ok {
 				label = strings.Replace(target, ":", string(filepath.Separator), 1)
-				toWatch = append(toWatch, filepath.Join(realPath, label))
+				toWatch[original] = filepath.Join(realPath, label)
 			}
 			continue
 		}
@@ -716,7 +869,7 @@ func (i *IBazel) labelsToWatch(labels []string) ([]string, error) {
 		}
 
 		label = strings.Replace(strings.TrimPrefix(label, "//"), ":", string(filepath.Separator), 1)
-		toWatch = append(toWatch, filepath.Join(workspacePath, label))
+		toWatch[original] = filepath.Join(workspacePath, label)
 	}
 
 	return toWatch, nil

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -17,6 +17,7 @@ package ibazel
 import (
 	"bytes"
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -42,6 +43,7 @@ var osExit = os.Exit
 var bazelNew = bazel.New
 var commandDefaultCommand = command.DefaultCommand
 var commandNotifyCommand = command.NotifyCommand
+var notifyOutputGroups = flag.String("notify_output_groups", "", "Comma-separated Bazel output groups included in structured build notifications")
 var exitMessages = map[os.Signal]string{
 	syscall.SIGINT:  "Subprocess killed from getting SIGINT (trigger SIGINT again to stop ibazel)",
 	syscall.SIGTERM: "Subprocess killed from getting SIGTERM",
@@ -467,7 +469,11 @@ func (i *IBazel) setupRun(target string) command.Command {
 	if commandNotify {
 		i.executionMode = notificationStartupExecution
 		log.Logf("Launching with notifications")
-		return commandNotifyCommand(i.startupArgs, i.bazelArgs, target, i.args, structuredNotify)
+		var outputGroups []string
+		if structuredNotify {
+			outputGroups = splitCommaSeparated(*notifyOutputGroups)
+		}
+		return commandNotifyCommand(i.startupArgs, i.bazelArgs, target, i.args, structuredNotify, outputGroups)
 	} else {
 		i.executionMode = defaultStartupExecution
 		return commandDefaultCommand(i.startupArgs, i.bazelArgs, target, i.args)
@@ -482,6 +488,16 @@ func (i *IBazel) prepareRun(target string) {
 	default:
 		i.state = QUERY
 	}
+}
+
+func splitCommaSeparated(value string) []string {
+	var values []string
+	for _, item := range strings.Split(value, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			values = append(values, item)
+		}
+	}
+	return values
 }
 
 func (i *IBazel) run(targets ...string) (*bytes.Buffer, error) {

--- a/internal/ibazel/ibazel_test.go
+++ b/internal/ibazel/ibazel_test.go
@@ -491,7 +491,7 @@ func TestIBazelRunStartsBeforeWatchQuery(t *testing.T) {
 	})
 
 	cmd := &mockCommand{}
-	commandNotifyCommand = func(_ []string, _ []string, _ string, _ []string, _ bool) command.Command {
+	commandNotifyCommand = func(_ []string, _ []string, _ string, _ []string, _ bool, _ []string) command.Command {
 		return cmd
 	}
 
@@ -516,16 +516,20 @@ func TestIBazelRunStartsBeforeWatchQuery(t *testing.T) {
 func TestPrepareRunNegotiatesNotificationsAndInitialState(t *testing.T) {
 	oldCommandNotifyCommand := commandNotifyCommand
 	defer func() { commandNotifyCommand = oldCommandNotifyCommand }()
+	oldNotifyOutputGroups := *notifyOutputGroups
+	*notifyOutputGroups = "generated, manifest"
+	defer func() { *notifyOutputGroups = oldNotifyOutputGroups }()
 
 	for _, test := range []struct {
 		name         string
 		tags         []string
 		structured   bool
 		initialState State
+		outputGroups []string
 	}{
 		{name: "default", initialState: QUERY},
 		{name: "legacy", tags: []string{"ibazel_notify_changes"}, initialState: RUN},
-		{name: "structured", tags: []string{"ibazel_notify_changes", "ibazel_notify_changes_v1"}, structured: true, initialState: RUN},
+		{name: "structured", tags: []string{"ibazel_notify_changes", "ibazel_notify_changes_v1"}, structured: true, initialState: RUN, outputGroups: []string{"generated", "manifest"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			i, mockBazel := newIBazel(t)
@@ -550,14 +554,17 @@ func TestPrepareRunNegotiatesNotificationsAndInitialState(t *testing.T) {
 			})
 
 			var structured bool
-			commandNotifyCommand = func(_ []string, _ []string, _ string, _ []string, enabled bool) command.Command {
+			var outputGroups []string
+			commandNotifyCommand = func(_ []string, _ []string, _ string, _ []string, enabled bool, groups []string) command.Command {
 				structured = enabled
+				outputGroups = groups
 				return &mockCommand{}
 			}
 
 			i.prepareRun(target)
 			assertEqual(t, test.structured, structured, "Structured notification mode")
 			assertEqual(t, test.initialState, i.state, "Initial run state")
+			assertEqual(t, test.outputGroups, outputGroups, "Notification output groups")
 		})
 	}
 }

--- a/internal/ibazel/ibazel_test.go
+++ b/internal/ibazel/ibazel_test.go
@@ -85,6 +85,7 @@ type mockCommand struct {
 
 	notifiedOfChanges bool
 	changes           []command.Change
+	impact            command.ChangeImpact
 	started           bool
 	terminated        bool
 
@@ -100,9 +101,10 @@ func (m *mockCommand) Start() (*bytes.Buffer, error) {
 	m.started = true
 	return nil, nil
 }
-func (m *mockCommand) NotifyOfChanges(changes []command.Change) *bytes.Buffer {
+func (m *mockCommand) NotifyOfChanges(changes []command.Change, impact command.ChangeImpact) *bytes.Buffer {
 	m.notifiedOfChanges = true
 	m.changes = changes
+	m.impact = impact
 	return nil
 }
 func (m *mockCommand) Terminate() {
@@ -224,24 +226,25 @@ func TestIBazelLoop(t *testing.T) {
 		}},
 	})
 	mockBazel.AddCQueryResponse(fmt.Sprintf("deps(set(%s))", target), &analysispb.CqueryResult{
-		Results: []*analysispb.ConfiguredTarget{{
-			Target: &blaze_query.Target{
-				Type: &ruleType,
-				Rule: &blaze_query.Rule{
-					Name: &target,
+		Results: []*analysispb.ConfiguredTarget{
+			{
+				Target: &blaze_query.Target{
+					Type: &ruleType,
+					Rule: &blaze_query.Rule{
+						Name:      &target,
+						RuleInput: []string{sourceFilePath},
+					},
 				},
 			},
-		}},
-	})
-	mockBazel.AddCQueryResponse(fmt.Sprintf("kind('source file', deps(set(%s)))", target), &analysispb.CqueryResult{
-		Results: []*analysispb.ConfiguredTarget{{
-			Target: &blaze_query.Target{
-				Type: &sourceFileType,
-				SourceFile: &blaze_query.SourceFile{
-					Name: &sourceFilePath,
+			{
+				Target: &blaze_query.Target{
+					Type: &sourceFileType,
+					SourceFile: &blaze_query.SourceFile{
+						Name: &sourceFilePath,
+					},
 				},
 			},
-		}},
+		},
 	})
 
 	outputBase := t.TempDir()
@@ -521,15 +524,16 @@ func TestPrepareRunNegotiatesNotificationsAndInitialState(t *testing.T) {
 	defer func() { *notifyOutputGroups = oldNotifyOutputGroups }()
 
 	for _, test := range []struct {
-		name         string
-		tags         []string
-		structured   bool
-		initialState State
-		outputGroups []string
+		name          string
+		tags          []string
+		structured    bool
+		initialState  State
+		outputGroups  []string
+		directTargets []string
 	}{
 		{name: "default", initialState: QUERY},
 		{name: "legacy", tags: []string{"ibazel_notify_changes"}, initialState: RUN},
-		{name: "structured", tags: []string{"ibazel_notify_changes", "ibazel_notify_changes_v1"}, structured: true, initialState: RUN, outputGroups: []string{"generated", "manifest"}},
+		{name: "structured", tags: []string{"ibazel_notify_changes", "ibazel_notify_changes_v1"}, structured: true, initialState: RUN, outputGroups: []string{"generated", "manifest"}, directTargets: []string{"//path/to:rpc", "//path/to:electron"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			i, mockBazel := newIBazel(t)
@@ -542,12 +546,15 @@ func TestPrepareRunNegotiatesNotificationsAndInitialState(t *testing.T) {
 					Target: &blaze_query.Target{
 						Type: blaze_query.Target_RULE.Enum(),
 						Rule: &blaze_query.Rule{
-							Name: proto.String(target),
-							Attribute: []*blaze_query.Attribute{{
-								Name:            proto.String("tags"),
-								Type:            &attributeType,
-								StringListValue: test.tags,
-							}},
+							Name:      proto.String(target),
+							RuleInput: test.directTargets,
+							Attribute: []*blaze_query.Attribute{
+								{
+									Name:            proto.String("tags"),
+									Type:            &attributeType,
+									StringListValue: test.tags,
+								},
+							},
 						},
 					},
 				}},
@@ -565,6 +572,7 @@ func TestPrepareRunNegotiatesNotificationsAndInitialState(t *testing.T) {
 			assertEqual(t, test.structured, structured, "Structured notification mode")
 			assertEqual(t, test.initialState, i.state, "Initial run state")
 			assertEqual(t, test.outputGroups, outputGroups, "Notification output groups")
+			assertEqual(t, test.directTargets, i.directTargets, "Direct targets")
 		})
 	}
 }
@@ -580,6 +588,78 @@ func TestChangeDetectedRecordsUniqueChanges(t *testing.T) {
 		{Path: "/workspace/path/to/BUILD", Kind: "graph"},
 	}
 	assertEqual(t, want, i.pendingChanges, "Unique changes for the current iteration")
+}
+
+func TestSourceOwnersDriveChangeImpact(t *testing.T) {
+	i, mockBazel := newIBazel(t)
+	defer i.Cleanup()
+
+	outputBase := t.TempDir()
+	if err := os.Mkdir(filepath.Join(outputBase, "external"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	mockBazel.SetInfo(map[string]string{
+		"output_base":  outputBase,
+		"install_base": t.TempDir(),
+	})
+
+	rpcSource := filepath.Join(t.TempDir(), "rpc.rs")
+	electronSource := filepath.Join(t.TempDir(), "electron.ts")
+	sharedSource := filepath.Join(t.TempDir(), "shared.txt")
+	rpcBuild := filepath.Join(t.TempDir(), "BUILD.bazel")
+	for _, path := range []string{rpcSource, electronSource, sharedSource, rpcBuild} {
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ruleType := blaze_query.Target_RULE
+	sourceType := blaze_query.Target_SOURCE_FILE
+	configuredRule := func(name string, inputs ...string) *analysispb.ConfiguredTarget {
+		return &analysispb.ConfiguredTarget{Target: &blaze_query.Target{
+			Type: &ruleType,
+			Rule: &blaze_query.Rule{Name: proto.String(name), RuleInput: inputs},
+		}}
+	}
+	configuredSource := func(name string) *analysispb.ConfiguredTarget {
+		return &analysispb.ConfiguredTarget{Target: &blaze_query.Target{
+			Type:       &sourceType,
+			SourceFile: &blaze_query.SourceFile{Name: proto.String(name)},
+		}}
+	}
+	rpcRule := configuredRule("//app:rpc", rpcSource, sharedSource)
+	rpcRule.Target.Rule.Location = proto.String(rpcBuild + ":1:1")
+	graph := &analysispb.CqueryResult{Results: []*analysispb.ConfiguredTarget{
+		rpcRule,
+		configuredRule("//app:electron", electronSource, sharedSource),
+		configuredSource(rpcSource),
+		configuredSource(electronSource),
+		configuredSource(sharedSource),
+	}}
+
+	i.directTargets = []string{"//app:rpc", "//app:electron"}
+	i.changeOwners, i.ownershipReady = i.sourceOwnersFromGraph(graph, map[string]string{
+		rpcSource:      rpcSource,
+		electronSource: electronSource,
+		sharedSource:   sharedSource,
+	})
+	resolved := func(path string) string {
+		result, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return result
+	}
+	i.pendingChanges = []command.Change{{Path: resolved(rpcSource), Kind: "source"}}
+	assertEqual(t, command.ChangeImpact{Targets: []string{"//app:rpc"}, Complete: true}, i.changeImpact(), "RPC change impact")
+	i.pendingChanges = []command.Change{{Path: resolved(rpcBuild), Kind: "graph"}}
+	assertEqual(t, command.ChangeImpact{Targets: []string{"//app:rpc"}, Complete: true}, i.changeImpact(), "RPC graph impact")
+
+	i.pendingChanges = []command.Change{
+		{Path: resolved(sharedSource), Kind: "source"},
+		{Path: filepath.Join(t.TempDir(), "BUILD"), Kind: "graph"},
+	}
+	assertEqual(t, command.ChangeImpact{Targets: []string{"//app:electron", "//app:rpc"}, Complete: false}, i.changeImpact(), "Incomplete shared change impact")
 }
 
 func TestHandleSignals_SIGINTWithoutRunningCommand(t *testing.T) {


### PR DESCRIPTION
## Why

Structured notification consumers receive source changes and build status, but not generated artifacts. They must rescan runfiles after every successful build.

This is stacked on #838 so notification targets receive a catch-up build after watch discovery, including an initial output snapshot.

## What changed

- add `--notify_output_groups` for structured notification targets
- collect requested groups from Bazel's JSON BEP, including transitive named sets and inline files
- preserve URI, inline contents, symlink target, digest, and length metadata
- emit deterministic output sets and mark them complete only after successful parsing
- add an end-to-end test using an actual Bazel output group

## Verification

`bazel test //internal/ibazel/bep:bep_test //internal/ibazel/command:command_test //internal/ibazel:ibazel_test //internal/e2e/notify_output_groups:notify_output_groups_test`
